### PR TITLE
change botocore version to 1.12.201

### DIFF
--- a/bring-custom-container.ipynb
+++ b/bring-custom-container.ipynb
@@ -105,6 +105,7 @@
     "!rm scikit_bring_your_own.zip\n",
     "!rm -rf scikit_bring_your_own\n",
     "!cat container/Dockerfile"
+    "pip install botocore==1.12.201"
    ]
   },
   {


### PR DESCRIPTION
without botocore change to 1.12.201, build container cell threw error "Credential named assume-role-with-web-identity not found"
The solution borrowed with pride from https://stackoverflow.com/questions/61753451/credential-named-assume-role-with-web-identity-not-found

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
