### PR TITLE
Update xgboost_direct_marketing_sagemaker.ipynb

### DIFF
--- a/xgboost_direct_marketing_sagemaker.ipynb
+++ b/xgboost_direct_marketing_sagemaker.ipynb
@@ -531,15 +531,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def predict(data, rows=500):\n",
+    "def predict(data, predictor, rows=500 ):\n",
     "    split_array = np.array_split(data, int(data.shape[0] / float(rows) + 1))\n",
     "    predictions = ''\n",
     "    for array in split_array:\n",
-    "        predictions = ','.join([predictions, xgb_predictor.predict(array).decode('utf-8')])\n",
+    "        predictions = ','.join([predictions, predictor.predict(array).decode('utf-8')])\n",
     "\n",
     "    return np.fromstring(predictions[1:], sep=',')\n",
     "\n",
-    "predictions = predict(test_data.drop(['y_no', 'y_yes'], axis=1).to_numpy())"
+    "predictions = predict(test_data.drop(['y_no', 'y_yes'], axis=1).to_numpy(), xgb_predictor)"
    ]
   },
   {
@@ -617,7 +617,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tuner.fit({'train': s3_input_train, 'validation': s3_input_validation}, include_cls_metadata=False,wait=False)"
+    "tuner.fit({'train': s3_input_train, 'validation': s3_input_validation})"
    ]
   },
   {
@@ -628,6 +628,57 @@
    "source": [
     "boto3.client('sagemaker').describe_hyper_parameter_tuning_job(\n",
     "HyperParameterTuningJobName=tuner.latest_tuning_job.job_name)['HyperParameterTuningJobStatus']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# return the best training job name\n",
+    "tuner.best_training_job()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#  Deploy the best trained or user specified model to an Amazon SageMaker endpoint\n",
+    "tuner_predictor = tuner.deploy(initial_instance_count=1,\n",
+    "                           instance_type='ml.m4.xlarge')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a serializer\n",
+    "tuner_predictor.serializer = sagemaker.serializers.CSVSerializer()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Predict\n",
+    "predictions = predict(test_data.drop(['y_no', 'y_yes'], axis=1).to_numpy(),tuner_predictor)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Collect predictions and convert from the CSV output our model provides into a NumPy array\n",
+    "pd.crosstab(index=test_data['y_yes'], columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
    ]
   },
   {
@@ -664,7 +715,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "tuner_predictor.delete_endpoint(delete_endpoint_config=True)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Update notebook to expand and automate the Amazon SageMaker automatic model tuning section

## Issue #8 

## Description of changes

- Wait for the Hyperparameter tuning job to finish by changing the parameters of the fit() function, also remove include_cls_metadata parameter as it is False by default.
- describe the best trained job (out of default 3 trained jobs)
- deploy the best trained model to a Sagemaker endpoint
- run prediction
- notice the difference between the previous prediction output, this is where the value sit, comparing this prediction with the previous one
- run clean-up


see issue #8 for an indepth description of this PR
