### PR TITLE
update get_pipleine() for missing variable

### DIFF
--- a/ML Pipelines scripts/pipeline.py
+++ b/ML Pipelines scripts/pipeline.py
@@ -83,6 +83,7 @@ def get_session(region, default_bucket):
 
 def get_pipeline(
     region,
+    sagemaker_project_arn=None,
     role=None,
     default_bucket=None,
     model_package_group_name="CustomerChurnPackageGroup",  # Choose any name


### PR DESCRIPTION
*Issue #, if available:* issue# 23
*Description of changes:*

In SageMaker Immersion Day Lab06, the CodeBuild process failed and in CloudWatch Log, you can see the exception: 
Exception: get_pipeline() got an unexpected keyword argument 'sagemaker_project_arn'

To fix the issue, would need to add sagemaker_project_arn=None in get_pipeline() function to initiate it. The CodeBuild can success after modification and I also confirmed Lab06 can be all set til the end after this issue got fixed. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
