### PR TITLE
Fix typo issue in comments

### DIFF
--- a/xgboost_debugger_demo.ipynb
+++ b/xgboost_debugger_demo.ipynb
@@ -842,7 +842,7 @@
     "\n",
     "- `rule_parameters`: In this parameter, you provide the runtime values of the parameter in your constructor.\n",
     "  You can still choose to pass in other values which may be necessary for your rule to be evaluated.\n",
-    "  In this example, you will use Amazon SageMaker's LossNotDecreasing rule to monitor the `metircs` collection.\n",
+    "  In this example, you will use Amazon SageMaker's LossNotDecreasing rule to monitor the `metrics` collection.\n",
     "  The rule will alert you if the tensors in `metrics` has not decreased for more than 10 steps."
    ]
   },


### PR DESCRIPTION
*Description of changes:*
Fixing typo issue in markdown cell of the notebook.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
