### PR TITLE
Iss26

### DIFF
--- a/SageMaker-ModelMonitoring.ipynb
+++ b/SageMaker-ModelMonitoring.ipynb
@@ -32,7 +32,6 @@
    "execution_count": 1,
    "source": [
     "%%time\n",
-    "# cell 01\n",
     "\n",
     "# Handful of configuration\n",
     "\n",
@@ -98,6 +97,7 @@
    "execution_count": 2,
    "source": [
     "# cell 02\n",
+    "\n",
     "# Upload some test files\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(\"test_upload/test.txt\").upload_file('test_data/upload-test-file.txt')\n",
     "print(\"Success! You are all set to proceed.\")"
@@ -129,6 +129,7 @@
    "execution_count": 3,
    "source": [
     "# cell 03\n",
+    "\n",
     "model_file = open(\"model/xgb-churn-prediction-model.tar.gz\", 'rb')\n",
     "s3_key = os.path.join(prefix, 'xgb-churn-prediction-model.tar.gz')\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(s3_key).upload_fileobj(model_file)"
@@ -149,6 +150,7 @@
    "execution_count": 4,
    "source": [
     "# cell 04\n",
+    "\n",
     "from time import gmtime, strftime\n",
     "from sagemaker.model import Model\n",
     "from sagemaker.image_uris import retrieve\n",
@@ -174,6 +176,7 @@
    "execution_count": 5,
    "source": [
     "# cell 05\n",
+    "\n",
     "from sagemaker.model_monitor import DataCaptureConfig\n",
     "\n",
     "endpoint_name = 'DEMO-xgb-churn-pred-model-monitor-' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
@@ -222,6 +225,7 @@
    "execution_count": 6,
    "source": [
     "# cell 06\n",
+    "\n",
     "from sagemaker.predictor import Predictor\n",
     "import sagemaker\n",
     "import time\n",
@@ -269,6 +273,7 @@
    "execution_count": 7,
    "source": [
     "# cell 07\n",
+    "\n",
     "s3_client = boto3.Session().client('s3')\n",
     "current_endpoint_capture_prefix = '{}/{}'.format(data_capture_prefix, endpoint_name)\n",
     "result = s3_client.list_objects(Bucket=bucket, Prefix=current_endpoint_capture_prefix)\n",
@@ -303,6 +308,7 @@
    "execution_count": 8,
    "source": [
     "# cell 08\n",
+    "\n",
     "def get_obj_body(obj_key):\n",
     "    return s3_client.get_object(Bucket=bucket, Key=obj_key).get('Body').read().decode(\"utf-8\")\n",
     "\n",
@@ -335,6 +341,7 @@
    "execution_count": 9,
    "source": [
     "# cell 09\n",
+    "\n",
     "import json\n",
     "print(json.dumps(json.loads(capture_file.split('\\n')[0]), indent=2))"
    ],
@@ -417,6 +424,7 @@
    "execution_count": 10,
    "source": [
     "# cell 10\n",
+    "\n",
     "# copy over the training dataset to Amazon S3 (if you already have it in Amazon S3, you could reuse it)\n",
     "baseline_prefix = prefix + '/baselining'\n",
     "baseline_data_prefix = baseline_prefix + '/data'\n",
@@ -444,6 +452,7 @@
    "execution_count": 11,
    "source": [
     "# cell 11\n",
+    "\n",
     "training_data_file = open(\"test_data/training-dataset-with-header.csv\", 'rb')\n",
     "s3_key = os.path.join(baseline_prefix, 'data', 'training-dataset-with-header.csv')\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(s3_key).upload_fileobj(training_data_file)"
@@ -470,6 +479,7 @@
    "execution_count": 12,
    "source": [
     "# cell 12\n",
+    "\n",
     "from sagemaker.model_monitor import DefaultModelMonitor\n",
     "from sagemaker.model_monitor.dataset_format import DatasetFormat\n",
     "\n",
@@ -3961,6 +3971,7 @@
    "execution_count": 13,
    "source": [
     "# cell 13\n",
+    "\n",
     "s3_client = boto3.Session().client('s3')\n",
     "result = s3_client.list_objects(Bucket=bucket, Prefix=baseline_results_prefix)\n",
     "report_files = [report_file.get(\"Key\") for report_file in result.get('Contents')]\n",
@@ -3985,6 +3996,7 @@
    "execution_count": 14,
    "source": [
     "# cell 14\n",
+    "\n",
     "import pandas as pd\n",
     "\n",
     "baseline_job = my_default_monitor.latest_baselining_job\n",
@@ -4303,6 +4315,7 @@
    "execution_count": 15,
    "source": [
     "# cell 15\n",
+    "\n",
     "constraints_df = pd.json_normalize(baseline_job.suggested_constraints().body_dict[\"features\"])\n",
     "constraints_df.head(10)"
    ],
@@ -4451,6 +4464,7 @@
    "execution_count": 16,
    "source": [
     "# cell 16\n",
+    "\n",
     "# First, copy over some test scripts to the S3 bucket so that they can be used for pre and post processing\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(code_prefix+\"/preprocessor.py\").upload_file('preprocessor.py')\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(code_prefix+\"/postprocessor.py\").upload_file('postprocessor.py')"
@@ -4470,6 +4484,7 @@
    "execution_count": 17,
    "source": [
     "# cell 17\n",
+    "\n",
     "from sagemaker.model_monitor import CronExpressionGenerator\n",
     "from time import gmtime, strftime\n",
     "\n",
@@ -4503,6 +4518,7 @@
    "execution_count": 18,
    "source": [
     "# cell 18\n",
+    "\n",
     "from threading import Thread\n",
     "from time import sleep\n",
     "import time\n",
@@ -4546,6 +4562,7 @@
    "execution_count": 19,
    "source": [
     "# cell 19\n",
+    "\n",
     "desc_schedule_result = my_default_monitor.describe_schedule()\n",
     "print('Schedule status: {}'.format(desc_schedule_result['MonitoringScheduleStatus']))"
    ],
@@ -4575,6 +4592,7 @@
    "execution_count": 20,
    "source": [
     "# cell 20\n",
+    "\n",
     "mon_executions = my_default_monitor.list_executions()\n",
     "print(\"We created a hourly schedule above and it will kick off executions ON the hour (plus 0 - 20 min buffer.\\nWe will have to wait till we hit the hour...\")\n",
     "\n",
@@ -4722,6 +4740,7 @@
    "execution_count": 21,
    "source": [
     "# cell 21\n",
+    "\n",
     "latest_execution = mon_executions[-1] # latest execution's index is -1, second to last is -2 and so on..\n",
     "time.sleep(60)\n",
     "latest_execution.wait(logs=False)\n",
@@ -4750,6 +4769,7 @@
    "execution_count": 22,
    "source": [
     "# cell 22\n",
+    "\n",
     "report_uri=latest_execution.output.destination\n",
     "print('Report Uri: {}'.format(report_uri))"
    ],
@@ -4776,6 +4796,7 @@
    "execution_count": 23,
    "source": [
     "# cell 23\n",
+    "\n",
     "from urllib.parse import urlparse\n",
     "s3uri = urlparse(report_uri)\n",
     "report_bucket = s3uri.netloc\n",
@@ -4824,6 +4845,7 @@
    "execution_count": 24,
    "source": [
     "# cell 24\n",
+    "\n",
     "violations = my_default_monitor.latest_monitoring_constraint_violations()\n",
     "pd.set_option('display.max_colwidth', None)\n",
     "constraints_df = pd.json_normalize(violations.body_dict[\"violations\"])\n",
@@ -4967,6 +4989,7 @@
    "execution_count": null,
    "source": [
     "# cell 25\n",
+    "\n",
     "#my_default_monitor.stop_monitoring_schedule()\n",
     "#my_default_monitor.start_monitoring_schedule()"
    ],
@@ -4989,6 +5012,7 @@
    "execution_count": null,
    "source": [
     "# cell 26\n",
+    "\n",
     "my_default_monitor.delete_monitoring_schedule()\n",
     "time.sleep(60) # actually wait for the deletion"
    ],
@@ -5000,6 +5024,7 @@
    "execution_count": null,
    "source": [
     "# cell 27\n",
+    "\n",
     "predictor.delete_endpoint()"
    ],
    "outputs": [],
@@ -5012,6 +5037,7 @@
    "execution_count": null,
    "source": [
     "# cell 28\n",
+    "\n",
     "predictor.delete_model()"
    ],
    "outputs": [],

--- a/TaxiFare_Predict_Liner_Learner.ipynb
+++ b/TaxiFare_Predict_Liner_Learner.ipynb
@@ -40,6 +40,7 @@
    "outputs": [],
    "source": [
     "# cell 01\n",
+    "\n",
     "!conda update pandas -y"
    ]
   },
@@ -50,6 +51,7 @@
    "outputs": [],
    "source": [
     "# cell 02\n",
+    "\n",
     "import os\n",
     "import boto3\n",
     "import re\n",
@@ -64,6 +66,7 @@
    "outputs": [],
    "source": [
     "# cell 03\n",
+    "\n",
     "role = sagemaker.get_execution_role()\n",
     "sess = sagemaker.Session()\n",
     "region = boto3.Session().region_name\n",
@@ -128,6 +131,7 @@
    ],
    "source": [
     "# cell 04\n",
+    "\n",
     "import boto3\n",
     "FILE_TRAIN = \"nyc-taxi.csv\"\n",
     "# s3 = boto3.client(\"s3\")\n",
@@ -179,6 +183,7 @@
    ],
    "source": [
     "# cell 05\n",
+    "\n",
     "df.info()"
    ]
   },
@@ -781,6 +786,7 @@
    ],
    "source": [
     "# cell 06\n",
+    "\n",
     "# Frequency tables for each categorical feature\n",
     "for column in df.select_dtypes(include=['object']).columns:\n",
     "    display(pd.crosstab(index=df[column], columns='% observations', normalize='columns'))\n",
@@ -835,6 +841,7 @@
    ],
    "source": [
     "# cell 07\n",
+    "\n",
     "df = df.drop(['payment_type', 'store_and_fwd_flag'], axis=1)\n",
     "df.info()"
    ]
@@ -875,6 +882,7 @@
    ],
    "source": [
     "# cell 08\n",
+    "\n",
     "df['dropoff_datetime']= pd.to_datetime(df['dropoff_datetime'])\n",
     "df['pickup_datetime']= pd.to_datetime(df['pickup_datetime'])\n",
     "df['journey_time'] = (df['dropoff_datetime'] - df['pickup_datetime'])\n",
@@ -925,6 +933,7 @@
    ],
    "source": [
     "# cell 09\n",
+    "\n",
     "df = df.drop(['dropoff_datetime', 'pickup_datetime'], axis=1)\n",
     "df.info()"
    ]
@@ -973,6 +982,7 @@
    ],
    "source": [
     "# cell 10\n",
+    "\n",
     "df = pd.get_dummies(df, dtype=float)\n",
     "df.info()"
    ]
@@ -991,6 +1001,7 @@
    "outputs": [],
    "source": [
     "# cell 11\n",
+    "\n",
     "import numpy as np\n",
     "\n",
     "train_data, validation_data, test_data = np.split(df.sample(frac=1, random_state=1729), [int(0.7 * len(df)), int(0.9 * len(df))])\n",
@@ -1006,6 +1017,7 @@
    "outputs": [],
    "source": [
     "# cell 12\n",
+    "\n",
     "boto3.Session().resource('s3').Bucket(data_bucket).Object(os.path.join(data_prefix, 'train/train.csv')).upload_file('train.csv')\n",
     "boto3.Session().resource('s3').Bucket(data_bucket).Object(os.path.join(data_prefix, 'validation/validation.csv')).upload_file('validation.csv')\n",
     "boto3.Session().resource('s3').Bucket(data_bucket).Object(os.path.join(data_prefix, 'test/test.csv')).upload_file('test.csv')"
@@ -1038,6 +1050,7 @@
    ],
    "source": [
     "# cell 13\n",
+    "\n",
     "# creating the inputs for the fit() function with the training and validation location\n",
     "s3_train_data = f\"s3://{data_bucket}/{data_prefix}/train\"\n",
     "print(f\"training files will be taken from: {s3_train_data}\")\n",
@@ -1096,6 +1109,7 @@
    ],
    "source": [
     "# cell 14\n",
+    "\n",
     "# getting the linear learner image according to the region\n",
     "from sagemaker.image_uris import retrieve\n",
     "\n",
@@ -1119,7 +1133,6 @@
     }
    ],
    "source": [
-    "# cell 15\n",
     "%%time\n",
     "import boto3\n",
     "import sagemaker\n",
@@ -3435,7 +3448,6 @@
     }
    ],
    "source": [
-    "# cell 16\n",
     "%%time\n",
     "linear.fit(inputs={\"train\": train_data, \"validation\": validation_data}, job_name=job_name)"
    ]
@@ -3466,7 +3478,6 @@
     }
    ],
    "source": [
-    "# cell 17\n",
     "%%time\n",
     "# creating the endpoint out of the trained model\n",
     "linear_predictor = linear.deploy(initial_instance_count=1, instance_type=\"ml.c4.xlarge\")\n",
@@ -3496,6 +3507,7 @@
    "outputs": [],
    "source": [
     "# cell 18\n",
+    "\n",
     "# configure the predictor to accept to serialize csv input and parse the reposne as json\n",
     "from sagemaker.serializers import CSVSerializer\n",
     "from sagemaker.deserializers import JSONDeserializer\n",
@@ -3533,7 +3545,6 @@
     }
    ],
    "source": [
-    "# cell 19\n",
     "%%time\n",
     "import json\n",
     "from itertools import islice\n",
@@ -3570,9 +3581,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# cell 20\n"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/TaxiFare_Predict_Liner_Learner.ipynb
+++ b/TaxiFare_Predict_Liner_Learner.ipynb
@@ -3581,7 +3581,10 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# cell 20\n",
+    "\n"
+   ]
   }
  ],
  "metadata": {

--- a/bias_and_explainability.ipynb
+++ b/bias_and_explainability.ipynb
@@ -62,6 +62,7 @@
    "outputs": [],
    "source": [
     "# cell 01\n",
+    "\n",
     "from sagemaker import Session\n",
     "session = Session()\n",
     "bucket = session.default_bucket()\n",
@@ -96,6 +97,7 @@
    "outputs": [],
    "source": [
     "# cell 02\n",
+    "\n",
     "adult_columns = [\"Age\", \"Workclass\", \"fnlwgt\", \"Education\", \"Education-Num\", \"Marital Status\",\n",
     "                 \"Occupation\", \"Relationship\", \"Ethnic group\", \"Sex\", \"Capital Gain\", \"Capital Loss\",\n",
     "                 \"Hours per week\", \"Country\", \"Target\"]\n",
@@ -151,6 +153,7 @@
    "outputs": [],
    "source": [
     "# cell 03\n",
+    "\n",
     "training_data = pd.read_csv(\"adult.data\",\n",
     "                             names=adult_columns,\n",
     "                             sep=r'\\s*,\\s*',\n",
@@ -185,6 +188,7 @@
    "outputs": [],
    "source": [
     "# cell 04\n",
+    "\n",
     "training_data['Sex'].value_counts().sort_values().plot(kind='bar', title='Counts of Sex', rot=0)"
    ]
   },
@@ -197,6 +201,7 @@
    "outputs": [],
    "source": [
     "# cell 05\n",
+    "\n",
     "training_data['Sex'].where(training_data['Target']=='>50K').value_counts().sort_values().plot(kind='bar', title='Counts of Sex earning >$50K', rot=0)"
    ]
   },
@@ -215,6 +220,7 @@
    "outputs": [],
    "source": [
     "# cell 06\n",
+    "\n",
     "from sklearn import preprocessing\n",
     "def number_encode_features(df):\n",
     "    result = df.copy()\n",
@@ -250,6 +256,7 @@
    "outputs": [],
    "source": [
     "# cell 07\n",
+    "\n",
     "training_data.head()"
    ]
   },
@@ -267,6 +274,7 @@
    "outputs": [],
    "source": [
     "# cell 08\n",
+    "\n",
     "from sagemaker.s3 import S3Uploader\n",
     "from sagemaker.inputs import TrainingInput\n",
     "\n",
@@ -291,6 +299,7 @@
    "outputs": [],
    "source": [
     "# cell 09\n",
+    "\n",
     "from sagemaker.image_uris import retrieve\n",
     "from sagemaker.estimator import Estimator\n",
     "\n",
@@ -328,6 +337,7 @@
    "outputs": [],
    "source": [
     "# cell 10\n",
+    "\n",
     "model_name = 'DEMO-clarify-model'\n",
     "model = xgb.create_model(name=model_name)\n",
     "container_def = model.prepare_container_def()\n",
@@ -351,6 +361,7 @@
    "outputs": [],
    "source": [
     "# cell 11\n",
+    "\n",
     "from sagemaker import clarify\n",
     "clarify_processor = clarify.SageMakerClarifyProcessor(role=role,\n",
     "                                                      instance_count=1,\n",
@@ -375,6 +386,7 @@
    "outputs": [],
    "source": [
     "# cell 12\n",
+    "\n",
     "bias_report_output_path = 's3://{}/{}/clarify-bias'.format(bucket, prefix)\n",
     "bias_data_config = clarify.DataConfig(s3_data_input_path=train_uri,\n",
     "                                      s3_output_path=bias_report_output_path,\n",
@@ -399,6 +411,7 @@
    "outputs": [],
    "source": [
     "# cell 13\n",
+    "\n",
     "model_config = clarify.ModelConfig(model_name=model_name,\n",
     "                                   instance_type='ml.m5.xlarge',\n",
     "                                   instance_count=1,\n",
@@ -420,6 +433,7 @@
    "outputs": [],
    "source": [
     "# cell 14\n",
+    "\n",
     "predictions_config = clarify.ModelPredictedLabelConfig(probability_threshold=0.8)"
    ]
   },
@@ -441,6 +455,7 @@
    "outputs": [],
    "source": [
     "# cell 15\n",
+    "\n",
     "bias_config = clarify.BiasConfig(label_values_or_threshold=[1],\n",
     "                                facet_name='Sex',\n",
     "                                facet_values_or_threshold=[0],\n",
@@ -472,6 +487,7 @@
    "outputs": [],
    "source": [
     "# cell 16\n",
+    "\n",
     "clarify_processor.run_bias(data_config=bias_data_config,\n",
     "                           bias_config=bias_config,\n",
     "                           model_config=model_config,\n",
@@ -512,6 +528,7 @@
    "outputs": [],
    "source": [
     "# cell 17\n",
+    "\n",
     "bias_report_output_path"
    ]
   },
@@ -537,6 +554,7 @@
    "outputs": [],
    "source": [
     "# cell 18\n",
+    "\n",
     "shap_config = clarify.SHAPConfig(baseline=[test_features.iloc[0].values.tolist()],\n",
     "                                 num_samples=15,\n",
     "                                 agg_method='mean_abs',\n",
@@ -557,6 +575,7 @@
    "outputs": [],
    "source": [
     "# cell 19\n",
+    "\n",
     "clarify_processor.run_explainability(data_config=explainability_data_config,\n",
     "                                     model_config=model_config,\n",
     "                                     explainability_config=shap_config)"
@@ -584,6 +603,7 @@
    "outputs": [],
    "source": [
     "# cell 20\n",
+    "\n",
     "explainability_output_path"
    ]
   },
@@ -602,6 +622,7 @@
    "outputs": [],
    "source": [
     "# cell 21\n",
+    "\n",
     "session.delete_model(model_name)"
    ]
   }

--- a/bring-custom-container.ipynb
+++ b/bring-custom-container.ipynb
@@ -97,7 +97,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 00\n",
+    "# cell 01\n",
+    "\n",
     "!pip install --upgrade aiobotocore"
    ]
   },
@@ -107,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 01\n",
+    "# cell 02\n",
     "\n",
     "!unzip scikit_bring_your_own.zip\n",
     "!mv scikit_bring_your_own/data/ ./lab03_data/\n",
@@ -129,7 +130,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 02\n",
+    "# cell 03\n",
+    "\n",
     "!pip install sagemaker-studio-image-build"
    ]
   },
@@ -147,7 +149,6 @@
    "outputs": [],
    "source": [
     "%%sh\n",
-    "# cell 03\n",
     "\n",
     "\n",
     "cd lab03_container\n",
@@ -172,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 04\n",
+    "# cell 05\n",
     "\n",
     "# S3 prefix\n",
     "prefix = 'DEMO-scikit-byo-iris'\n",
@@ -202,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 05\n",
+    "# cell 06\n",
     "\n",
     "import sagemaker as sage\n",
     "from time import gmtime, strftime\n",
@@ -225,7 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 06\n",
+    "# cell 07\n",
     "\n",
     "WORK_DIRECTORY = 'lab03_data'\n",
     "\n",
@@ -254,7 +255,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 07\n",
+    "# cell 08\n",
     "\n",
     "account = sess.boto_session.client('sts').get_caller_identity()['Account']\n",
     "region = sess.boto_session.region_name\n",
@@ -284,7 +285,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 08\n",
+    "# cell 09\n",
+    "\n",
     "from sagemaker.serializers import CSVSerializer\n",
     "predictor = tree.deploy(initial_instance_count=1, instance_type='ml.m4.xlarge', serializer=CSVSerializer())"
    ]
@@ -309,7 +311,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 09\n",
+    "# cell 10\n",
     "\n",
     "shape=pd.read_csv(file_location, header=None)\n",
     "shape.sample(3)"
@@ -321,7 +323,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 10\n",
+    "# cell 11\n",
     "\n",
     "# drop the label column in the training set\n",
     "shape.drop(shape.columns[[0]],axis=1,inplace=True)\n",
@@ -334,7 +336,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 11\n",
+    "# cell 12\n",
     "\n",
     "import itertools\n",
     "\n",
@@ -360,7 +362,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 12\n",
+    "# cell 13\n",
     "\n",
     "print(predictor.predict(test_data.values).decode('utf-8'))"
    ]
@@ -379,7 +381,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 13\n",
+    "# cell 14\n",
+    "\n",
     "sess.delete_endpoint(predictor.endpoint_name)"
    ]
   },
@@ -389,7 +392,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 14\n",
+    "# cell 15\n",
+    "\n",
     "!rm -rf lab03_container lab03_data"
    ]
   }

--- a/bring-custom-script.ipynb
+++ b/bring-custom-script.ipynb
@@ -337,7 +337,10 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# cell 15\n",
+    "\n"
+   ]
   }
  ],
  "metadata": {

--- a/bring-custom-script.ipynb
+++ b/bring-custom-script.ipynb
@@ -32,6 +32,7 @@
    "outputs": [],
    "source": [
     "# cell 01\n",
+    "\n",
     "import os\n",
     "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
@@ -62,6 +63,7 @@
    "outputs": [],
    "source": [
     "# cell 02\n",
+    "\n",
     "training_data_uri = 's3://sagemaker-sample-data-{}/tensorflow/mnist'.format(region)"
    ]
   },
@@ -110,6 +112,7 @@
    "outputs": [],
    "source": [
     "# cell 04\n",
+    "\n",
     "from sagemaker.tensorflow import TensorFlow\n",
     "\n",
     "\n",
@@ -136,6 +139,7 @@
    "outputs": [],
    "source": [
     "# cell 05\n",
+    "\n",
     "mnist_estimator2 = TensorFlow(entry_point='mnist-2.py',\n",
     "                             role=role,\n",
     "                             instance_count=2,\n",
@@ -168,6 +172,7 @@
    "outputs": [],
    "source": [
     "# cell 06\n",
+    "\n",
     "mnist_estimator.fit(training_data_uri)"
    ]
   },
@@ -185,6 +190,7 @@
    "outputs": [],
    "source": [
     "# cell 07\n",
+    "\n",
     "mnist_estimator2.fit(training_data_uri)"
    ]
   },
@@ -203,6 +209,7 @@
    "outputs": [],
    "source": [
     "# cell 08\n",
+    "\n",
     "predictor = mnist_estimator.deploy(initial_instance_count=1, instance_type='ml.m4.xlarge')"
    ]
   },
@@ -220,6 +227,7 @@
    "outputs": [],
    "source": [
     "# cell 09\n",
+    "\n",
     "predictor2 = mnist_estimator2.deploy(initial_instance_count=1, instance_type='ml.m4.xlarge')"
    ]
   },
@@ -238,6 +246,7 @@
    "outputs": [],
    "source": [
     "# cell 10\n",
+    "\n",
     "import numpy as np\n",
     "\n",
     "!aws --region {region} s3 cp s3://sagemaker-sample-data-{region}/tensorflow/mnist/train_data.npy train_data.npy\n",
@@ -263,6 +272,7 @@
    "outputs": [],
    "source": [
     "# cell 11\n",
+    "\n",
     "predictions = predictor.predict(train_data[:50])\n",
     "for i in range(0, 50):\n",
     "    prediction = predictions['predictions'][i]['classes']\n",
@@ -284,6 +294,7 @@
    "outputs": [],
    "source": [
     "# cell 12\n",
+    "\n",
     "predictions2 = predictor2.predict(train_data[:50])\n",
     "for i in range(0, 50):\n",
     "    prediction = np.argmax(predictions2['predictions'][i])\n",
@@ -306,6 +317,7 @@
    "outputs": [],
    "source": [
     "# cell 13\n",
+    "\n",
     "predictor.delete_endpoint()"
    ]
   },
@@ -316,6 +328,7 @@
    "outputs": [],
    "source": [
     "# cell 14\n",
+    "\n",
     "predictor2.delete_endpoint()"
    ]
   },
@@ -324,9 +337,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# cell 15\n"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/feature_store_xgboost_direct_marketing_sagemaker.ipynb
+++ b/feature_store_xgboost_direct_marketing_sagemaker.ipynb
@@ -58,6 +58,7 @@
    "outputs": [],
    "source": [
     "# cell 01\n",
+    "\n",
     "import sagemaker\n",
     "bucket=sagemaker.Session().default_bucket()\n",
     "prefix = 'sagemaker/DEMO-xgboost-dm'\n",
@@ -84,6 +85,7 @@
    "outputs": [],
    "source": [
     "# cell 02\n",
+    "\n",
     "import numpy as np                                # For matrix operations and numerical processing\n",
     "import pandas as pd                               # For munging tabular data\n",
     "import matplotlib.pyplot as plt                   # For charts and visualizations\n",
@@ -133,6 +135,7 @@
    "outputs": [],
    "source": [
     "# cell 03\n",
+    "\n",
     "from sagemaker.session import Session\n",
     "from sagemaker.feature_store.feature_group import FeatureGroup\n",
     "\n",
@@ -167,6 +170,7 @@
    ],
    "source": [
     "# cell 04\n",
+    "\n",
     "# Build SQL query to features group\n",
     "fs_query = feature_group.athena_query()\n",
     "fs_table = fs_query.table_name\n",
@@ -181,6 +185,7 @@
    "outputs": [],
    "source": [
     "# cell 05\n",
+    "\n",
     "# Run Athena query. The output is loaded to a Pandas dataframe.\n",
     "fs_query.run(query_string=query_string, output_location='s3://'+bucket+'/'+prefix+'/fs_query_results/')\n",
     "fs_query.wait()\n",
@@ -194,6 +199,7 @@
    "outputs": [],
    "source": [
     "# cell 06\n",
+    "\n",
     "model_data = model_data.drop(['fs_id', 'fs_time', 'write_time', 'api_invocation_time', 'is_deleted'], axis=1)"
    ]
   },
@@ -1202,6 +1208,7 @@
    ],
    "source": [
     "# cell 07\n",
+    "\n",
     "model_data"
    ]
   },
@@ -1221,6 +1228,7 @@
    "outputs": [],
    "source": [
     "# cell 08\n",
+    "\n",
     "train_data, validation_data, test_data = np.split(model_data.sample(frac=1, random_state=1729), [int(0.7 * len(model_data)), int(0.9 * len(model_data))])   # Randomly sort the data then split out first 70%, second 20%, and last 10%"
    ]
   },
@@ -1238,6 +1246,7 @@
    "outputs": [],
    "source": [
     "# cell 09\n",
+    "\n",
     "pd.concat([train_data['y_yes'], train_data.drop(['y_no', 'y_yes'], axis=1)], axis=1).to_csv('train.csv', index=False, header=False)\n",
     "pd.concat([validation_data['y_yes'], validation_data.drop(['y_no', 'y_yes'], axis=1)], axis=1).to_csv('validation.csv', index=False, header=False)"
    ]
@@ -1256,6 +1265,7 @@
    "outputs": [],
    "source": [
     "# cell 10\n",
+    "\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(os.path.join(prefix, 'train/train.csv')).upload_file('train.csv')\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(os.path.join(prefix, 'validation/validation.csv')).upload_file('validation.csv')"
    ]
@@ -1292,6 +1302,7 @@
    "outputs": [],
    "source": [
     "# cell 11\n",
+    "\n",
     "container = sagemaker.image_uris.retrieve(region=boto3.Session().region_name, framework='xgboost', version='latest')"
    ]
   },
@@ -1309,6 +1320,7 @@
    "outputs": [],
    "source": [
     "# cell 12\n",
+    "\n",
     "s3_input_train = sagemaker.inputs.TrainingInput(s3_data='s3://{}/{}/train'.format(bucket, prefix), content_type='csv')\n",
     "s3_input_validation = sagemaker.inputs.TrainingInput(s3_data='s3://{}/{}/validation/'.format(bucket, prefix), content_type='csv')"
    ]
@@ -1561,6 +1573,7 @@
    ],
    "source": [
     "# cell 13\n",
+    "\n",
     "sess = sagemaker.Session()\n",
     "\n",
     "xgb = sagemaker.estimator.Estimator(container,\n",
@@ -1606,6 +1619,7 @@
    ],
    "source": [
     "# cell 14\n",
+    "\n",
     "xgb_predictor = xgb.deploy(initial_instance_count=1,\n",
     "                           instance_type='ml.m4.xlarge')"
    ]
@@ -1631,6 +1645,7 @@
    "outputs": [],
    "source": [
     "# cell 15\n",
+    "\n",
     "xgb_predictor.serializer = sagemaker.serializers.CSVSerializer()"
    ]
   },
@@ -1653,6 +1668,7 @@
    "outputs": [],
    "source": [
     "# cell 16\n",
+    "\n",
     "def predict(data, predictor, rows=500 ):\n",
     "    split_array = np.array_split(data, int(data.shape[0] / float(rows) + 1))\n",
     "    predictions = ''\n",
@@ -1735,6 +1751,7 @@
    ],
    "source": [
     "# cell 17\n",
+    "\n",
     "pd.crosstab(index=test_data['y_yes'], columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
    ]
   },
@@ -1763,6 +1780,7 @@
    "outputs": [],
    "source": [
     "# cell 18\n",
+    "\n",
     "from sagemaker.tuner import IntegerParameter, CategoricalParameter, ContinuousParameter, HyperparameterTuner\n",
     "hyperparameter_ranges = {'eta': ContinuousParameter(0, 1),\n",
     "                            'min_child_weight': ContinuousParameter(1, 10),\n",
@@ -1777,6 +1795,7 @@
    "outputs": [],
    "source": [
     "# cell 19\n",
+    "\n",
     "objective_metric_name = 'validation:auc'"
    ]
   },
@@ -1787,6 +1806,7 @@
    "outputs": [],
    "source": [
     "# cell 20\n",
+    "\n",
     "tuner = HyperparameterTuner(xgb,\n",
     "                            objective_metric_name,\n",
     "                            hyperparameter_ranges,\n",
@@ -1801,6 +1821,7 @@
    "outputs": [],
    "source": [
     "# cell 21\n",
+    "\n",
     "tuner.fit({'train': s3_input_train, 'validation': s3_input_validation})"
    ]
   },
@@ -1811,6 +1832,7 @@
    "outputs": [],
    "source": [
     "# cell 22\n",
+    "\n",
     "boto3.client('sagemaker').describe_hyper_parameter_tuning_job(\n",
     "HyperParameterTuningJobName=tuner.latest_tuning_job.job_name)['HyperParameterTuningJobStatus']"
    ]
@@ -1822,6 +1844,7 @@
    "outputs": [],
    "source": [
     "# cell 23\n",
+    "\n",
     "# return the best training job name\n",
     "tuner.best_training_job()"
    ]
@@ -1833,6 +1856,7 @@
    "outputs": [],
    "source": [
     "# cell 24\n",
+    "\n",
     "#  Deploy the best trained or user specified model to an Amazon SageMaker endpoint\n",
     "tuner_predictor = tuner.deploy(initial_instance_count=1,\n",
     "                           instance_type='ml.m4.xlarge')"
@@ -1845,6 +1869,7 @@
    "outputs": [],
    "source": [
     "# cell 25\n",
+    "\n",
     "# Create a serializer\n",
     "tuner_predictor.serializer = sagemaker.serializers.CSVSerializer()"
    ]
@@ -1856,6 +1881,7 @@
    "outputs": [],
    "source": [
     "# cell 26\n",
+    "\n",
     "# Predict\n",
     "predictions = predict(test_data.drop(['y_no', 'y_yes'], axis=1).to_numpy(),tuner_predictor)"
    ]
@@ -1867,6 +1893,7 @@
    "outputs": [],
    "source": [
     "# cell 27\n",
+    "\n",
     "# Collect predictions and convert from the CSV output our model provides into a NumPy array\n",
     "pd.crosstab(index=test_data['y_yes'], columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
    ]
@@ -1898,6 +1925,7 @@
    "outputs": [],
    "source": [
     "# cell 28\n",
+    "\n",
     "xgb_predictor.delete_endpoint(delete_endpoint_config=True)"
    ]
   },
@@ -1908,6 +1936,7 @@
    "outputs": [],
    "source": [
     "# cell 29\n",
+    "\n",
     "tuner_predictor.delete_endpoint(delete_endpoint_config=True)"
    ]
   }

--- a/processing_xgboost.ipynb
+++ b/processing_xgboost.ipynb
@@ -42,6 +42,7 @@
    "outputs": [],
    "source": [
     "# cell 01\n",
+    "\n",
     "import sagemaker\n",
     "bucket=sagemaker.Session().default_bucket()\n",
     "prefix = 'sagemaker/DEMO-xgboost-dm'\n",
@@ -68,6 +69,7 @@
    "outputs": [],
    "source": [
     "# cell 02\n",
+    "\n",
     "import numpy as np                                # For matrix operations and numerical processing\n",
     "import pandas as pd                               # For munging tabular data\n",
     "import matplotlib.pyplot as plt                   # For charts and visualizations\n",
@@ -101,6 +103,7 @@
    "outputs": [],
    "source": [
     "# cell 03\n",
+    "\n",
     "!wget https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip\n",
     "\n",
     "with zipfile.ZipFile('bank-additional.zip', 'r') as zip_ref:\n",
@@ -121,6 +124,7 @@
    "outputs": [],
    "source": [
     "# cell 04\n",
+    "\n",
     "data = pd.read_csv('./bank-additional/bank-additional-full.csv')\n",
     "pd.set_option('display.max_columns', 500)     # Make sure we can see all of the columns\n",
     "pd.set_option('display.max_rows', 20)         # Keep the output on one page\n",
@@ -141,6 +145,7 @@
    "outputs": [],
    "source": [
     "# cell 05\n",
+    "\n",
     "from sagemaker import Session\n",
     "\n",
     "sess = Session()\n",
@@ -170,7 +175,6 @@
    "outputs": [],
    "source": [
     "%%writefile preprocessing.py\n",
-    "# cell 06\n",
     "\n",
     "\n",
     "import pandas as pd\n",
@@ -230,6 +234,7 @@
    "outputs": [],
    "source": [
     "# cell 07\n",
+    "\n",
     "train_path = f\"s3://{bucket}/{prefix}/train\"\n",
     "validation_path = f\"s3://{bucket}/{prefix}/validation\"\n",
     "test_path = f\"s3://{bucket}/{prefix}/test\""
@@ -242,6 +247,7 @@
    "outputs": [],
    "source": [
     "# cell 08\n",
+    "\n",
     "from sagemaker.sklearn.processing import SKLearnProcessor\n",
     "from sagemaker.processing import ProcessingInput, ProcessingOutput\n",
     "from sagemaker import get_execution_role\n",
@@ -293,6 +299,7 @@
    ],
    "source": [
     "# cell 09\n",
+    "\n",
     "!aws s3 ls $train_path/"
    ]
   },
@@ -328,6 +335,7 @@
    "outputs": [],
    "source": [
     "# cell 10\n",
+    "\n",
     "container = sagemaker.image_uris.retrieve(region=boto3.Session().region_name, framework='xgboost', version='latest')"
    ]
   },
@@ -345,6 +353,7 @@
    "outputs": [],
    "source": [
     "# cell 11\n",
+    "\n",
     "s3_input_train = sagemaker.inputs.TrainingInput(s3_data=train_path.format(bucket, prefix), content_type='csv')\n",
     "s3_input_validation = sagemaker.inputs.TrainingInput(s3_data=validation_path.format(bucket, prefix), content_type='csv')"
    ]
@@ -371,6 +380,7 @@
    "outputs": [],
    "source": [
     "# cell 12\n",
+    "\n",
     "sess = sagemaker.Session()\n",
     "\n",
     "xgb = sagemaker.estimator.Estimator(container,\n",
@@ -408,6 +418,7 @@
    "outputs": [],
    "source": [
     "# cell 13\n",
+    "\n",
     "xgb_predictor = xgb.deploy(initial_instance_count=1,\n",
     "                           instance_type='ml.m4.xlarge')"
    ]
@@ -433,6 +444,7 @@
    "outputs": [],
    "source": [
     "# cell 14\n",
+    "\n",
     "xgb_predictor.serializer = sagemaker.serializers.CSVSerializer()"
    ]
   },
@@ -455,6 +467,7 @@
    "outputs": [],
    "source": [
     "# cell 15\n",
+    "\n",
     "!aws s3 cp $test_path/test_x.csv /tmp/test_x.csv\n",
     "!aws s3 cp $test_path/test_y.csv /tmp/test_y.csv"
    ]
@@ -466,6 +479,7 @@
    "outputs": [],
    "source": [
     "# cell 16\n",
+    "\n",
     "def predict(data, predictor, rows=500 ):\n",
     "    split_array = np.array_split(data, int(data.shape[0] / float(rows) + 1))\n",
     "    predictions = ''\n",
@@ -493,6 +507,7 @@
    "outputs": [],
    "source": [
     "# cell 17\n",
+    "\n",
     "pd.crosstab(index=test_y['y'].values, columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
    ]
   },
@@ -521,6 +536,7 @@
    "outputs": [],
    "source": [
     "# cell 18\n",
+    "\n",
     "from sagemaker.tuner import IntegerParameter, CategoricalParameter, ContinuousParameter, HyperparameterTuner\n",
     "hyperparameter_ranges = {'eta': ContinuousParameter(0, 1),\n",
     "                            'min_child_weight': ContinuousParameter(1, 10),\n",
@@ -535,6 +551,7 @@
    "outputs": [],
    "source": [
     "# cell 19\n",
+    "\n",
     "objective_metric_name = 'validation:auc'"
    ]
   },
@@ -545,6 +562,7 @@
    "outputs": [],
    "source": [
     "# cell 20\n",
+    "\n",
     "tuner = HyperparameterTuner(xgb,\n",
     "                            objective_metric_name,\n",
     "                            hyperparameter_ranges,\n",
@@ -559,6 +577,7 @@
    "outputs": [],
    "source": [
     "# cell 21\n",
+    "\n",
     "tuner.fit({'train': s3_input_train, 'validation': s3_input_validation})"
    ]
   },
@@ -569,6 +588,7 @@
    "outputs": [],
    "source": [
     "# cell 22\n",
+    "\n",
     "boto3.client('sagemaker').describe_hyper_parameter_tuning_job(\n",
     "HyperParameterTuningJobName=tuner.latest_tuning_job.job_name)['HyperParameterTuningJobStatus']"
    ]
@@ -580,6 +600,7 @@
    "outputs": [],
    "source": [
     "# cell 23\n",
+    "\n",
     "# return the best training job name\n",
     "tuner.best_training_job()"
    ]
@@ -591,6 +612,7 @@
    "outputs": [],
    "source": [
     "# cell 24\n",
+    "\n",
     "#  Deploy the best trained or user specified model to an Amazon SageMaker endpoint\n",
     "tuner_predictor = tuner.deploy(initial_instance_count=1,\n",
     "                           instance_type='ml.m4.xlarge')"
@@ -603,6 +625,7 @@
    "outputs": [],
    "source": [
     "# cell 25\n",
+    "\n",
     "# Create a serializer\n",
     "tuner_predictor.serializer = sagemaker.serializers.CSVSerializer()"
    ]
@@ -614,6 +637,7 @@
    "outputs": [],
    "source": [
     "# cell 26\n",
+    "\n",
     "# Predict\n",
     "predictions = predict(test_x.to_numpy(),tuner_predictor)"
    ]
@@ -625,6 +649,7 @@
    "outputs": [],
    "source": [
     "# cell 27\n",
+    "\n",
     "# Collect predictions and convert from the CSV output our model provides into a NumPy array\n",
     "pd.crosstab(index=test_y['y'].values, columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
    ]
@@ -656,6 +681,7 @@
    "outputs": [],
    "source": [
     "# cell 28\n",
+    "\n",
     "xgb_predictor.delete_endpoint(delete_endpoint_config=True)"
    ]
   },
@@ -666,6 +692,7 @@
    "outputs": [],
    "source": [
     "# cell 29\n",
+    "\n",
     "tuner_predictor.delete_endpoint(delete_endpoint_config=True)"
    ]
   }

--- a/sagemaker_autopilot_direct_marketing.ipynb
+++ b/sagemaker_autopilot_direct_marketing.ipynb
@@ -63,6 +63,7 @@
    "outputs": [],
    "source": [
     "# cell 01\n",
+    "\n",
     "import sagemaker\n",
     "import boto3\n",
     "from sagemaker import get_execution_role\n",
@@ -168,6 +169,7 @@
    ],
    "source": [
     "# cell 02\n",
+    "\n",
     "!wget -N https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip\n",
     "!conda install -y -c conda-forge unzip\n",
     "!unzip -o bank-additional.zip\n",
@@ -575,6 +577,7 @@
    ],
    "source": [
     "# cell 03\n",
+    "\n",
     "import pandas as pd\n",
     "\n",
     "data = pd.read_csv(local_data_path)\n",
@@ -610,6 +613,7 @@
    "outputs": [],
    "source": [
     "# cell 04\n",
+    "\n",
     "train_data = data.sample(frac=0.8,random_state=200)\n",
     "\n",
     "test_data = data.drop(train_data.index)\n",
@@ -641,6 +645,7 @@
    ],
    "source": [
     "# cell 05\n",
+    "\n",
     "train_file = 'train_data.csv';\n",
     "train_data.to_csv(train_file, index=False, header=True)\n",
     "train_data_s3_path = session.upload_data(path=train_file, key_prefix=prefix + \"/train\")\n",
@@ -675,6 +680,7 @@
    "outputs": [],
    "source": [
     "# cell 06\n",
+    "\n",
     "input_data_config = [{\n",
     "      'DataSource': {\n",
     "        'S3DataSource': {\n",
@@ -751,6 +757,7 @@
    ],
    "source": [
     "# cell 07\n",
+    "\n",
     "from time import gmtime, strftime, sleep\n",
     "timestamp_suffix = strftime('%d-%H-%M-%S', gmtime())\n",
     "\n",
@@ -839,6 +846,7 @@
    ],
    "source": [
     "# cell 08\n",
+    "\n",
     "print ('JobStatus - Secondary Status')\n",
     "print('------------------------------')\n",
     "\n",
@@ -886,6 +894,7 @@
    ],
    "source": [
     "# cell 09\n",
+    "\n",
     "best_candidate = sm.describe_auto_ml_job(AutoMLJobName=auto_ml_job_name)['BestCandidate']\n",
     "best_candidate_name = best_candidate['CandidateName']\n",
     "print(best_candidate)\n",
@@ -921,6 +930,7 @@
    ],
    "source": [
     "# cell 10\n",
+    "\n",
     "model_name = 'automl-banking-model-' + timestamp_suffix\n",
     "\n",
     "model = sm.create_model(Containers=best_candidate['InferenceContainers'],\n",
@@ -964,6 +974,7 @@
    ],
    "source": [
     "# cell 11\n",
+    "\n",
     "transform_job_name = 'automl-banking-transform-' + timestamp_suffix\n",
     "\n",
     "transform_input = {\n",
@@ -1029,6 +1040,7 @@
    ],
    "source": [
     "# cell 12\n",
+    "\n",
     "print ('JobStatus')\n",
     "print('----------')\n",
     "\n",
@@ -1154,6 +1166,7 @@
    ],
    "source": [
     "# cell 13\n",
+    "\n",
     "s3_output_key = '{}/inference-results/test_data.csv.out'.format(prefix);\n",
     "local_inference_results_path = 'inference_results.csv'\n",
     "\n",
@@ -1194,6 +1207,7 @@
    ],
    "source": [
     "# cell 14\n",
+    "\n",
     "candidates = sm.list_candidates_for_auto_ml_job(AutoMLJobName=auto_ml_job_name, SortBy='FinalObjectiveMetricValue')['Candidates']\n",
     "index = 1\n",
     "for candidate in candidates:\n",
@@ -1230,6 +1244,7 @@
    ],
    "source": [
     "# cell 15\n",
+    "\n",
     "sm.describe_auto_ml_job(AutoMLJobName=auto_ml_job_name)['AutoMLJobArtifacts']['CandidateDefinitionNotebookLocation']\n"
    ]
   },
@@ -1259,6 +1274,7 @@
    ],
    "source": [
     "# cell 16\n",
+    "\n",
     "sm.describe_auto_ml_job(AutoMLJobName=auto_ml_job_name)['AutoMLJobArtifacts']['DataExplorationNotebookLocation']\n"
    ]
   },
@@ -1278,6 +1294,7 @@
    "outputs": [],
    "source": [
     "# cell 17\n",
+    "\n",
     "#s3 = boto3.resource('s3')\n",
     "#bucket = s3.Bucket(bucket)\n",
     "\n",

--- a/sklearn-end2end.ipynb
+++ b/sklearn-end2end.ipynb
@@ -41,6 +41,7 @@
    "outputs": [],
    "source": [
     "# cell 01\n",
+    "\n",
     "import sagemaker\n",
     "bucket=sagemaker.Session().default_bucket()\n",
     "prefix = 'sagemaker/sklearn-end-2end-immday'\n",
@@ -67,6 +68,7 @@
    "outputs": [],
    "source": [
     "# cell 02\n",
+    "\n",
     "import numpy as np                                # For matrix operations and numerical processing\n",
     "import pandas as pd                               # For munging tabular data\n",
     "import matplotlib.pyplot as plt                   # For charts and visualizations\n",
@@ -88,6 +90,7 @@
    "outputs": [],
    "source": [
     "# cell 03\n",
+    "\n",
     "pd.__version__"
    ]
   },
@@ -117,6 +120,7 @@
    "outputs": [],
    "source": [
     "# cell 04\n",
+    "\n",
     "!wget https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip\n",
     "\n",
     "with zipfile.ZipFile('bank-additional.zip', 'r') as zip_ref:\n",
@@ -137,6 +141,7 @@
    "outputs": [],
    "source": [
     "# cell 05\n",
+    "\n",
     "data = pd.read_csv('./bank-additional/bank-additional-full.csv')\n",
     "pd.set_option('display.max_columns', 500)     # Make sure we can see all of the columns\n",
     "pd.set_option('display.max_rows', 20)         # Keep the output on one page\n",
@@ -157,6 +162,7 @@
    "outputs": [],
    "source": [
     "# cell 06\n",
+    "\n",
     "from sagemaker import Session\n",
     "\n",
     "sess = Session()\n",
@@ -185,7 +191,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 07\n",
     "%%writefile preprocessing.py\n",
     "\n",
     "import pandas as pd\n",
@@ -245,6 +250,7 @@
    "outputs": [],
    "source": [
     "# cell 08\n",
+    "\n",
     "train_path = f\"s3://{bucket}/{prefix}/train\"\n",
     "validation_path = f\"s3://{bucket}/{prefix}/validation\"\n",
     "test_path = f\"s3://{bucket}/{prefix}/test\""
@@ -257,6 +263,7 @@
    "outputs": [],
    "source": [
     "# cell 09\n",
+    "\n",
     "from sagemaker.sklearn.processing import SKLearnProcessor\n",
     "from sagemaker.processing import ProcessingInput, ProcessingOutput\n",
     "from sagemaker import get_execution_role\n",
@@ -322,6 +329,7 @@
    "outputs": [],
    "source": [
     "# cell 10\n",
+    "\n",
     "s3_input_train = sagemaker.inputs.TrainingInput(s3_data=train_path.format(bucket, prefix), content_type='csv')\n",
     "s3_input_validation = sagemaker.inputs.TrainingInput(s3_data=validation_path.format(bucket, prefix), content_type='csv')"
    ]
@@ -339,7 +347,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cell 11\n",
     "%%writefile sklearn-train.py\n",
     "\n",
     "from sklearn.ensemble import RandomForestClassifier\n",
@@ -394,6 +401,7 @@
    "outputs": [],
    "source": [
     "# cell 12\n",
+    "\n",
     "# We use the Estimator from the SageMaker Python SDK\n",
     "from sagemaker import get_execution_role\n",
     "from sagemaker.sklearn.estimator import SKLearn\n",
@@ -437,6 +445,7 @@
    "outputs": [],
    "source": [
     "# cell 13\n",
+    "\n",
     "sklearn_predictor = sklearn_estimator.deploy(initial_instance_count=1,\n",
     "                           instance_type='ml.m4.xlarge')"
    ]
@@ -462,6 +471,7 @@
    "outputs": [],
    "source": [
     "# cell 14\n",
+    "\n",
     "sklearn_predictor.serializer = sagemaker.serializers.CSVSerializer()"
    ]
   },
@@ -484,6 +494,7 @@
    "outputs": [],
    "source": [
     "# cell 15\n",
+    "\n",
     "!aws s3 cp $test_path/test_x.csv /tmp/test_x.csv\n",
     "!aws s3 cp $test_path/test_y.csv /tmp/test_y.csv"
    ]
@@ -495,6 +506,7 @@
    "outputs": [],
    "source": [
     "# cell 16\n",
+    "\n",
     "test_x = pd.read_csv('/tmp/test_x.csv', names=[f'{i}' for i in range(59)])\n",
     "test_y = pd.read_csv('/tmp/test_y.csv', names=['y'])\n",
     "predictions = sklearn_predictor.predict(test_x.values)"
@@ -514,6 +526,7 @@
    "outputs": [],
    "source": [
     "# cell 17\n",
+    "\n",
     "pd.crosstab(index=test_y['y'].values, columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
    ]
   },
@@ -561,6 +574,7 @@
    "outputs": [],
    "source": [
     "# cell 18\n",
+    "\n",
     "transformer_output_path = f\"s3://{bucket}/{prefix}/transformer-output\"\n",
     "\n",
     "sklearn_transformer = sklearn_estimator.transformer(\n",
@@ -583,6 +597,7 @@
    "outputs": [],
    "source": [
     "# cell 19\n",
+    "\n",
     "!aws s3 cp $transformer_output_path/test_x.csv.out /tmp/predictions.txt"
    ]
   },
@@ -593,6 +608,7 @@
    "outputs": [],
    "source": [
     "# cell 20\n",
+    "\n",
     "import json\n",
     "\n",
     "with open('/tmp/predictions.txt', 'r') as r:\n",
@@ -607,6 +623,7 @@
    "outputs": [],
    "source": [
     "# cell 21\n",
+    "\n",
     "pd.crosstab(index=test_y['y'].values, columns=predictions, rownames=['actuals'], colnames=['predictions'])"
    ]
   },
@@ -626,6 +643,7 @@
    "outputs": [],
    "source": [
     "# cell 22\n",
+    "\n",
     "from sagemaker.tuner import IntegerParameter, CategoricalParameter, ContinuousParameter, HyperparameterTuner\n",
     "hyperparameter_ranges = {\"n-estimators\": IntegerParameter(50, 250), \"min-samples-leaf\": IntegerParameter(1, 10)}\n"
    ]
@@ -637,6 +655,7 @@
    "outputs": [],
    "source": [
     "# cell 23\n",
+    "\n",
     "objective_metric_name = 'model_accuracy'"
    ]
   },
@@ -647,6 +666,7 @@
    "outputs": [],
    "source": [
     "# cell 24\n",
+    "\n",
     "tuner = HyperparameterTuner(sklearn_estimator,\n",
     "                            objective_metric_name,\n",
     "                            hyperparameter_ranges,\n",
@@ -663,6 +683,7 @@
    "outputs": [],
    "source": [
     "# cell 25\n",
+    "\n",
     "tuner.fit({'train': s3_input_train, 'test': s3_input_validation})"
    ]
   },
@@ -673,6 +694,7 @@
    "outputs": [],
    "source": [
     "# cell 26\n",
+    "\n",
     "boto3.client('sagemaker').describe_hyper_parameter_tuning_job(\n",
     "HyperParameterTuningJobName=tuner.latest_tuning_job.job_name)['HyperParameterTuningJobStatus']"
    ]
@@ -684,6 +706,7 @@
    "outputs": [],
    "source": [
     "# cell 27\n",
+    "\n",
     "# return the best training job name\n",
     "tuner.best_training_job()"
    ]
@@ -695,6 +718,7 @@
    "outputs": [],
    "source": [
     "# cell 28\n",
+    "\n",
     "#  Deploy the best trained or user specified model to an Amazon SageMaker endpoint\n",
     "tuner_predictor = tuner.deploy(initial_instance_count=1, instance_type='ml.m4.xlarge')\n",
     "tuner_predictor.serializer = sagemaker.serializers.CSVSerializer()"
@@ -707,6 +731,7 @@
    "outputs": [],
    "source": [
     "# cell 29\n",
+    "\n",
     "# Deploy the best one and predict\n",
     "predictions = tuner_predictor.predict(test_x.values)\n",
     "pd.crosstab(index=test_y['y'].values, columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
@@ -739,6 +764,7 @@
    "outputs": [],
    "source": [
     "# cell 30\n",
+    "\n",
     "sklearn_predictor.delete_endpoint(delete_endpoint_config=True)"
    ]
   },
@@ -749,6 +775,7 @@
    "outputs": [],
    "source": [
     "# cell 31\n",
+    "\n",
     "tuner_predictor.delete_endpoint(delete_endpoint_config=True)"
    ]
   }

--- a/util-cell-enumerate.py
+++ b/util-cell-enumerate.py
@@ -56,7 +56,7 @@ def renumber_code_cell(code_cell):
 
   # add a new  number
   insert_at_line_number=0 # in general, add to the beginning of the block
-  if len(code_cell["source"])>0 and not code_cell["source"][0].strip().startswith('%%'): 
+  if len(code_cell["source"])==0 or not code_cell["source"][0].strip().startswith('%%'): 
     # this is the usual case where line numbers can be prepended to the block
     code_cell["source"].insert(insert_at_line_number,'# cell {:02d}\n'.format(cell_number))
     code_cell["source"].insert(insert_at_line_number+1,'\n')

--- a/util-cell-enumerate.py
+++ b/util-cell-enumerate.py
@@ -36,7 +36,7 @@ def arg_check(path):
     sys.exit()
 
   if not path.endswith('.ipynb'):
-    print('The notebook does not have the expected .inbpy suffix')
+    print('The notebook does not have the expected .ipynb suffix')
     sys.exit()
 
   if not os.path.isfile(path):
@@ -50,12 +50,16 @@ def renumber_code_cell(code_cell):
   # strip any old numbers
   code_cell["source"] = [ line_of_code for line_of_code in code_cell["source"] if not has_cell_number.match(line_of_code)]
 
+  # strip any leading blank lines
+  while len(code_cell["source"]) > 0 and len(code_cell["source"][0].strip()) == 0:
+    code_cell["source"].pop(0)
+
   # add a new  number
   insert_at_line_number=0 # in general, add to the beginning of the block
-  if len(code_cell["source"])>0 and code_cell["source"][0].startswith('%%sh'): 
-    # this is rare case where line number cannot be prepended to the block
-    insert_at_line_number=1
-  code_cell["source"].insert(insert_at_line_number,'# cell {:02d}\n'.format(cell_number))
+  if len(code_cell["source"])>0 and not code_cell["source"][0].strip().startswith('%%'): 
+    # this is the usual case where line numbers can be prepended to the block
+    code_cell["source"].insert(insert_at_line_number,'# cell {:02d}\n'.format(cell_number))
+    code_cell["source"].insert(insert_at_line_number+1,'\n')
   cell_number += 1
   return code_cell
 

--- a/xgboost_debugger_demo.ipynb
+++ b/xgboost_debugger_demo.ipynb
@@ -1712,7 +1712,10 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# cell 27\n",
+    "\n"
+   ]
   }
  ],
  "metadata": {

--- a/xgboost_debugger_demo.ipynb
+++ b/xgboost_debugger_demo.ipynb
@@ -44,6 +44,7 @@
    "outputs": [],
    "source": [
     "# cell 01\n",
+    "\n",
     "# Define IAM role\n",
     "import boto3\n",
     "import sagemaker\n",
@@ -99,6 +100,7 @@
    ],
    "source": [
     "# cell 02\n",
+    "\n",
     "import numpy as np                                # For matrix operations and numerical processing\n",
     "import pandas as pd                               # For munging tabular data\n",
     "import matplotlib.pyplot as plt                   # For charts and visualizations\n",
@@ -160,6 +162,7 @@
    ],
    "source": [
     "# cell 03\n",
+    "\n",
     "!wget https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip\n",
     "!conda install -y -c conda-forge unzip\n",
     "!unzip -o bank-additional.zip"
@@ -554,6 +557,7 @@
    ],
    "source": [
     "# cell 04\n",
+    "\n",
     "data = pd.read_csv('./bank-additional/bank-additional-full.csv')\n",
     "pd.set_option('display.max_rows',10)\n",
     "data"
@@ -631,6 +635,7 @@
    "outputs": [],
    "source": [
     "# cell 05\n",
+    "\n",
     "data['no_previous_contact'] = np.where(data['pdays'] == 999, 1, 0)                                 # Indicator variable to capture when pdays takes a value of 999\n",
     "data['not_working'] = np.where(np.in1d(data['job'], ['student', 'retired', 'unemployed']), 1, 0)   # Indicator for individuals not actively employed\n",
     "model_data = pd.get_dummies(data)                                                                  # Convert categorical variables to sets of indicators"
@@ -654,6 +659,7 @@
    "outputs": [],
    "source": [
     "# cell 06\n",
+    "\n",
     "model_data = model_data.drop(['duration', 'emp.var.rate', 'cons.price.idx', 'cons.conf.idx', 'euribor3m', 'nr.employed'], axis=1)"
    ]
   },
@@ -673,6 +679,7 @@
    "outputs": [],
    "source": [
     "# cell 07\n",
+    "\n",
     "train_data, validation_data, test_data = np.split(model_data.sample(frac=1, random_state=1729), [int(0.7 * len(model_data)), int(0.9 * len(model_data))])   # Randomly sort the data then split out first 70%, second 20%, and last 10%"
    ]
   },
@@ -690,6 +697,7 @@
    "outputs": [],
    "source": [
     "# cell 08\n",
+    "\n",
     "pd.concat([train_data['y_yes'], train_data.drop(['y_no', 'y_yes'], axis=1)], axis=1).to_csv('train.csv', index=False, header=False)\n",
     "pd.concat([validation_data['y_yes'], validation_data.drop(['y_no', 'y_yes'], axis=1)], axis=1).to_csv('validation.csv', index=False, header=False)"
    ]
@@ -708,6 +716,7 @@
    "outputs": [],
    "source": [
     "# cell 09\n",
+    "\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(os.path.join(prefix, 'train/train.csv')).upload_file('train.csv')\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(os.path.join(prefix, 'validation/validation.csv')).upload_file('validation.csv')"
    ]
@@ -735,6 +744,7 @@
    "outputs": [],
    "source": [
     "# cell 10\n",
+    "\n",
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
     "container = sagemaker.image_uris.retrieve(region=boto3.Session().region_name, framework='xgboost', version='1.0-1')"
    ]
@@ -753,6 +763,7 @@
    "outputs": [],
    "source": [
     "# cell 11\n",
+    "\n",
     "s3_input_train = sagemaker.TrainingInput(s3_data='s3://{}/{}/train'.format(bucket, prefix), content_type='csv')\n",
     "s3_input_validation = sagemaker.TrainingInput(s3_data='s3://{}/{}/validation/'.format(bucket, prefix), content_type='csv')"
    ]
@@ -764,6 +775,7 @@
    "outputs": [],
    "source": [
     "# cell 12\n",
+    "\n",
     "base_job_name = \"demo-smdebug-xgboost-regression\"\n",
     "bucket_path='s3://{}/{}/output'.format(bucket, prefix)"
    ]
@@ -868,6 +880,7 @@
    "outputs": [],
    "source": [
     "# cell 13\n",
+    "\n",
     "from sagemaker.debugger import rule_configs, Rule, DebuggerHookConfig, CollectionConfig\n",
     "from sagemaker.estimator import Estimator\n",
     "sess = sagemaker.Session()\n",
@@ -921,6 +934,7 @@
    "outputs": [],
    "source": [
     "# cell 14\n",
+    "\n",
     "xgboost_estimator.set_hyperparameters(max_depth=5,\n",
     "                        eta=0.2,\n",
     "                        gamma=4,\n",
@@ -988,6 +1002,7 @@
    ],
    "source": [
     "# cell 16\n",
+    "\n",
     "import time\n",
     "from time import gmtime, strftime\n",
     "\n",
@@ -1036,6 +1051,7 @@
    ],
    "source": [
     "# cell 17\n",
+    "\n",
     "from smdebug.trials import create_trial\n",
     "\n",
     "description = client.describe_training_job(TrainingJobName=job_name)\n",
@@ -1399,6 +1415,7 @@
    ],
    "source": [
     "# cell 18\n",
+    "\n",
     "trial.tensor_names()"
    ]
   },
@@ -1466,6 +1483,7 @@
    ],
    "source": [
     "# cell 19\n",
+    "\n",
     "trial.tensor(\"predictions\").values()"
    ]
   },
@@ -1494,6 +1512,7 @@
    ],
    "source": [
     "# cell 20\n",
+    "\n",
     "type(trial.tensor(\"predictions\").value(10))"
    ]
   },
@@ -1515,6 +1534,7 @@
    "outputs": [],
    "source": [
     "# cell 21\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
     "import re\n",
@@ -1570,6 +1590,7 @@
    ],
    "source": [
     "# cell 22\n",
+    "\n",
     "plot_collection(trial, \"metrics\")"
    ]
   },
@@ -1591,6 +1612,7 @@
    "outputs": [],
    "source": [
     "# cell 23\n",
+    "\n",
     "def plot_feature_importance(trial, importance_type=\"weight\"):\n",
     "    SUPPORTED_IMPORTANCE_TYPES = [\"weight\", \"gain\", \"cover\", \"total_gain\", \"total_cover\"]\n",
     "    if importance_type not in SUPPORTED_IMPORTANCE_TYPES:\n",
@@ -1621,6 +1643,7 @@
    ],
    "source": [
     "# cell 24\n",
+    "\n",
     "plot_feature_importance(trial)"
    ]
   },
@@ -1644,6 +1667,7 @@
    ],
    "source": [
     "# cell 25\n",
+    "\n",
     "plot_feature_importance(trial, importance_type=\"cover\")"
    ]
   },
@@ -1679,6 +1703,7 @@
    ],
    "source": [
     "# cell 26\n",
+    "\n",
     "plot_collection(trial,\"average_shap\")"
    ]
   },
@@ -1687,9 +1712,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# cell 27\n"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/xgboost_direct_marketing_sagemaker.ipynb
+++ b/xgboost_direct_marketing_sagemaker.ipynb
@@ -56,6 +56,7 @@
    "outputs": [],
    "source": [
     "# cell 01\n",
+    "\n",
     "!pip install --upgrade pandas"
    ]
   },
@@ -68,6 +69,7 @@
    "outputs": [],
    "source": [
     "# cell 02\n",
+    "\n",
     "import sagemaker\n",
     "bucket=sagemaker.Session().default_bucket()\n",
     "prefix = 'sagemaker/DEMO-xgboost-dm'\n",
@@ -94,6 +96,7 @@
    "outputs": [],
    "source": [
     "# cell 03\n",
+    "\n",
     "import numpy as np                                # For matrix operations and numerical processing\n",
     "import pandas as pd                               # For munging tabular data\n",
     "import matplotlib.pyplot as plt                   # For charts and visualizations\n",
@@ -115,6 +118,7 @@
    "outputs": [],
    "source": [
     "# cell 04\n",
+    "\n",
     "pd.__version__"
    ]
   },
@@ -144,6 +148,7 @@
    "outputs": [],
    "source": [
     "# cell 05\n",
+    "\n",
     "!wget https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip\n",
     "\n",
     "with zipfile.ZipFile('bank-additional.zip', 'r') as zip_ref:\n",
@@ -164,6 +169,7 @@
    "outputs": [],
    "source": [
     "# cell 06\n",
+    "\n",
     "data = pd.read_csv('./bank-additional/bank-additional-full.csv')\n",
     "pd.set_option('display.max_columns', 500)     # Make sure we can see all of the columns\n",
     "pd.set_option('display.max_rows', 20)         # Keep the output on one page\n",
@@ -231,6 +237,7 @@
    "outputs": [],
    "source": [
     "# cell 07\n",
+    "\n",
     "# Frequency tables for each categorical feature\n",
     "for column in data.select_dtypes(include=['object']).columns:\n",
     "    display(pd.crosstab(index=data[column], columns='% observations', normalize='columns'))\n",
@@ -267,6 +274,7 @@
    "outputs": [],
    "source": [
     "# cell 08\n",
+    "\n",
     "for column in data.select_dtypes(include=['object']).columns:\n",
     "    if column != 'y':\n",
     "        display(pd.crosstab(index=data[column], columns=data['y'], normalize='columns'))\n",
@@ -296,6 +304,7 @@
    "outputs": [],
    "source": [
     "# cell 09\n",
+    "\n",
     "display(data.corr())\n",
     "pd.plotting.scatter_matrix(data, figsize=(12, 12))\n",
     "plt.show()"
@@ -336,6 +345,7 @@
    "outputs": [],
    "source": [
     "# cell 10\n",
+    "\n",
     "data['no_previous_contact'] = np.where(data['pdays'] == 999, 1, 0)                                 # Indicator variable to capture when pdays takes a value of 999\n",
     "data['not_working'] = np.where(np.in1d(data['job'], ['student', 'retired', 'unemployed']), 1, 0)   # Indicator for individuals not actively employed\n",
     "model_data = pd.get_dummies(data)                                                                  # Convert categorical variables to sets of indicators"
@@ -359,6 +369,7 @@
    "outputs": [],
    "source": [
     "# cell 11\n",
+    "\n",
     "model_data = model_data.drop(['duration', 'emp.var.rate', 'cons.price.idx', 'cons.conf.idx', 'euribor3m', 'nr.employed'], axis=1)"
    ]
   },
@@ -378,6 +389,7 @@
    "outputs": [],
    "source": [
     "# cell 12\n",
+    "\n",
     "train_data, validation_data, test_data = np.split(model_data.sample(frac=1, random_state=1729), [int(0.7 * len(model_data)), int(0.9 * len(model_data))])   # Randomly sort the data then split out first 70%, second 20%, and last 10%"
    ]
   },
@@ -395,6 +407,7 @@
    "outputs": [],
    "source": [
     "# cell 13\n",
+    "\n",
     "pd.concat([train_data['y_yes'], train_data.drop(['y_no', 'y_yes'], axis=1)], axis=1).to_csv('train.csv', index=False, header=False)\n",
     "pd.concat([validation_data['y_yes'], validation_data.drop(['y_no', 'y_yes'], axis=1)], axis=1).to_csv('validation.csv', index=False, header=False)"
    ]
@@ -413,6 +426,7 @@
    "outputs": [],
    "source": [
     "# cell 14\n",
+    "\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(os.path.join(prefix, 'train/train.csv')).upload_file('train.csv')\n",
     "boto3.Session().resource('s3').Bucket(bucket).Object(os.path.join(prefix, 'validation/validation.csv')).upload_file('validation.csv')"
    ]
@@ -449,6 +463,7 @@
    "outputs": [],
    "source": [
     "# cell 15\n",
+    "\n",
     "container = sagemaker.image_uris.retrieve(region=boto3.Session().region_name, framework='xgboost', version='latest')"
    ]
   },
@@ -466,6 +481,7 @@
    "outputs": [],
    "source": [
     "# cell 16\n",
+    "\n",
     "s3_input_train = sagemaker.inputs.TrainingInput(s3_data='s3://{}/{}/train'.format(bucket, prefix), content_type='csv')\n",
     "s3_input_validation = sagemaker.inputs.TrainingInput(s3_data='s3://{}/{}/validation/'.format(bucket, prefix), content_type='csv')"
    ]
@@ -492,6 +508,7 @@
    "outputs": [],
    "source": [
     "# cell 17\n",
+    "\n",
     "sess = sagemaker.Session()\n",
     "\n",
     "xgb = sagemaker.estimator.Estimator(container,\n",
@@ -529,6 +546,7 @@
    "outputs": [],
    "source": [
     "# cell 18\n",
+    "\n",
     "xgb_predictor = xgb.deploy(initial_instance_count=1,\n",
     "                           instance_type='ml.m4.xlarge')"
    ]
@@ -554,6 +572,7 @@
    "outputs": [],
    "source": [
     "# cell 19\n",
+    "\n",
     "xgb_predictor.serializer = sagemaker.serializers.CSVSerializer()"
    ]
   },
@@ -576,6 +595,7 @@
    "outputs": [],
    "source": [
     "# cell 20\n",
+    "\n",
     "def predict(data, predictor, rows=500 ):\n",
     "    split_array = np.array_split(data, int(data.shape[0] / float(rows) + 1))\n",
     "    predictions = ''\n",
@@ -601,6 +621,7 @@
    "outputs": [],
    "source": [
     "# cell 21\n",
+    "\n",
     "pd.crosstab(index=test_data['y_yes'], columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
    ]
   },
@@ -629,6 +650,7 @@
    "outputs": [],
    "source": [
     "# cell 22\n",
+    "\n",
     "from sagemaker.tuner import IntegerParameter, CategoricalParameter, ContinuousParameter, HyperparameterTuner\n",
     "hyperparameter_ranges = {'eta': ContinuousParameter(0, 1),\n",
     "                            'min_child_weight': ContinuousParameter(1, 10),\n",
@@ -643,6 +665,7 @@
    "outputs": [],
    "source": [
     "# cell 23\n",
+    "\n",
     "objective_metric_name = 'validation:auc'"
    ]
   },
@@ -653,6 +676,7 @@
    "outputs": [],
    "source": [
     "# cell 24\n",
+    "\n",
     "tuner = HyperparameterTuner(xgb,\n",
     "                            objective_metric_name,\n",
     "                            hyperparameter_ranges,\n",
@@ -667,6 +691,7 @@
    "outputs": [],
    "source": [
     "# cell 25\n",
+    "\n",
     "tuner.fit({'train': s3_input_train, 'validation': s3_input_validation})"
    ]
   },
@@ -677,6 +702,7 @@
    "outputs": [],
    "source": [
     "# cell 26\n",
+    "\n",
     "boto3.client('sagemaker').describe_hyper_parameter_tuning_job(\n",
     "HyperParameterTuningJobName=tuner.latest_tuning_job.job_name)['HyperParameterTuningJobStatus']"
    ]
@@ -688,6 +714,7 @@
    "outputs": [],
    "source": [
     "# cell 27\n",
+    "\n",
     "# return the best training job name\n",
     "tuner.best_training_job()"
    ]
@@ -699,6 +726,7 @@
    "outputs": [],
    "source": [
     "# cell 28\n",
+    "\n",
     "#  Deploy the best trained or user specified model to an Amazon SageMaker endpoint\n",
     "tuner_predictor = tuner.deploy(initial_instance_count=1,\n",
     "                           instance_type='ml.m4.xlarge')"
@@ -711,6 +739,7 @@
    "outputs": [],
    "source": [
     "# cell 29\n",
+    "\n",
     "# Create a serializer\n",
     "tuner_predictor.serializer = sagemaker.serializers.CSVSerializer()"
    ]
@@ -722,6 +751,7 @@
    "outputs": [],
    "source": [
     "# cell 30\n",
+    "\n",
     "# Predict\n",
     "predictions = predict(test_data.drop(['y_no', 'y_yes'], axis=1).to_numpy(),tuner_predictor)"
    ]
@@ -733,6 +763,7 @@
    "outputs": [],
    "source": [
     "# cell 31\n",
+    "\n",
     "# Collect predictions and convert from the CSV output our model provides into a NumPy array\n",
     "pd.crosstab(index=test_data['y_yes'], columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
    ]
@@ -764,6 +795,7 @@
    "outputs": [],
    "source": [
     "# cell 32\n",
+    "\n",
     "xgb_predictor.delete_endpoint(delete_endpoint_config=True)"
    ]
   },
@@ -774,6 +806,7 @@
    "outputs": [],
    "source": [
     "# cell 33\n",
+    "\n",
     "tuner_predictor.delete_endpoint(delete_endpoint_config=True)"
    ]
   }

--- a/xgboost_experiments.ipynb
+++ b/xgboost_experiments.ipynb
@@ -31,6 +31,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 01\n",
+    "\n",
     "!pip install -qU sagemaker>=2.37.0\n",
     "!pip install -qU sagemaker-experiments>=0.1.24"
    ]
@@ -48,6 +50,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 02\n",
+    "\n",
     "import boto3\n",
     "import io\n",
     "import numpy as np\n",
@@ -86,6 +90,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 03\n",
+    "\n",
     "!wget https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip -O /tmp/bank-additional.zip\n",
     "\n",
     "with zipfile.ZipFile('/tmp/bank-additional.zip', 'r') as zip_ref:\n",
@@ -113,6 +119,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 04\n",
+    "\n",
     "sagemaker_session = sagemaker.Session()\n",
     "\n",
     "train_path = sagemaker_session.upload_data('/tmp/train.csv', bucket=bucket, key_prefix=os.path.join(prefix, 'train/train.csv'))\n",
@@ -146,6 +154,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 05\n",
+    "\n",
     "example_experiment = Experiment.create(\n",
     "    experiment_name=f\"direct-marketing-{int(time.time())}\", \n",
     "    description=\"Using SM Experiments with the Direct Marketing dataset.\"\n",
@@ -169,6 +179,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 06\n",
+    "\n",
     "trial_name = f\"direct-marketing-xgboost-{int(time.time())}\"\n",
     "trial = Trial.create(\n",
     "    trial_name=trial_name, \n",
@@ -189,6 +201,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 07\n",
+    "\n",
     "# Retrieve the container image\n",
     "container = sagemaker.image_uris.retrieve(\n",
     "    region=boto3.Session().region_name, \n",
@@ -249,6 +263,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 08\n",
+    "\n",
     "from sagemaker.tuner import IntegerParameter, CategoricalParameter, ContinuousParameter, HyperparameterTuner\n",
     "\n",
     "# Setup the hyperparameter ranges\n",
@@ -292,6 +308,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 09\n",
+    "\n",
     "from smexperiments.search_expression import Filter, Operator, SearchExpression\n",
     "from smexperiments.trial import Trial\n",
     "from smexperiments.trial_component import TrialComponent\n",
@@ -331,6 +349,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 10\n",
+    "\n",
     "trial_component_analytics = ExperimentAnalytics(\n",
     "    sagemaker_session=Session(sess, sm), \n",
     "    experiment_name=example_experiment.experiment_name,\n",
@@ -347,6 +367,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# cell 11\n",
+    "\n",
     "df.plot.scatter(x='num_round', y='ObjectiveMetric - Last')"
    ]
   },


### PR DESCRIPTION
*Issue 26*

It has been pointed out that inserting `# cell 01` into code cells with magic commands such as `%%time` is problematic . 

*Description of changes:*

Modified the  `util-cell-enumerate.py` file to suppress automated cell numbering in blocks that have `%%` special commands.   

All the changes in the `*.ipynb` files is a result of running the script over all the source files. So you can inspect to see what impact this script has on the Notebooks.  

I had also considered the suggestion of inserting the number in the Markdown above a block, but this made the impact on the notebooks even more severe and would require more code to keep correct.   Offering this strategy as a more frugal alternative. 

Note: For cosmetic reasons, I've also  modified the script to uniformly add exactly extra one blank line after the `# cell 01` comments. 
