### PR TITLE
Update pipeline.py to fix bug introduced by breaking change in SageMaker SDK

### DIFF
--- a/ML Pipelines scripts/pipeline.py
+++ b/ML Pipelines scripts/pipeline.py
@@ -106,12 +106,8 @@ def get_pipeline(
     processing_instance_count = ParameterInteger(
         name="ProcessingInstanceCount", default_value=1
     )
-    processing_instance_type = ParameterString(
-        name="ProcessingInstanceType", default_value="ml.m5.xlarge"
-    )
-    training_instance_type = ParameterString(
-        name="TrainingInstanceType", default_value="ml.m5.xlarge"
-    )
+    processing_instance_type = "ml.m5.xlarge"
+    training_instance_type = "ml.m5.xlarge"
     model_approval_status = ParameterString(
         name="ModelApprovalStatus",
         default_value="PendingManualApproval",  # ModelApprovalStatus can be set to a default of "Approved" if you don't want manual approval.


### PR DESCRIPTION
Fixing bug introduced by a change in the SageMaker SDK.

https://github.com/aws/sagemaker-python-sdk/issues/3141

*Issue #, if available: https://github.com/aws-samples/amazon-sagemaker-immersion-day/issues/55

*Description of changes:*
A recent change in the SageMaker SDK requires the instance type parameters to be passed in as strings.

https://github.com/aws/sagemaker-python-sdk/issues/3141

Resulting error:

```Exception: instance_type should not be a pipeline variable (<class 'sagemaker.workflow.parameters.ParameterString'>)
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pipelines/run_pipeline.py", line 77, in main
    pipeline = get_pipeline_driver(args.module_name, args.kwargs)
  File "/root/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pipelines/_utils.py", line 33, in get_pipeline_driver
    return _imports.get_pipeline(**kwargs)
  File "/root/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pipelines/customer_churn/pipeline.py", line 125, in get_pipeline
    sklearn_processor = SKLearnProcessor(
  File "/root/.pyenv/versions/3.8.13/lib/python3.8/site-packages/sagemaker/sklearn/processing.py", line 90, in __init__
    image_uri = image_uris.retrieve(
  File "/root/.pyenv/versions/3.8.13/lib/python3.8/site-packages/sagemaker/image_uris.py", line 117, in retrieve
    raise ValueError("%s should not be a pipeline variable (%s)" % (name, type(val)))
ValueError: instance_type should not be a pipeline variable (<class 'sagemaker.workflow.parameters.ParameterString'>)
[Container] 2022/06/24 23:03:51 Command did not exit successfully run-pipeline --module-name pipelines.customer_churn.pipeline \
  --role-arn $SAGEMAKER_PIPELINE_ROLE_ARN \
  --tags "[{\"Key\":\"sagemaker:project-name\", \"Value\":\"${SAGEMAKER_PROJECT_NAME}\"}, {\"Key\":\"sagemaker:project-id\", \"Value\":\"${SAGEMAKER_PROJECT_ID}\"}]" \
  --kwargs "```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
