### PR TITLE
project_id is not accepted in get_pipeline

### DIFF
--- a/ML Pipelines scripts/codebuild-buildspec.yml
+++ b/ML Pipelines scripts/codebuild-buildspec.yml
@@ -15,5 +15,5 @@ phases:
         run-pipeline --module-name pipelines.customer_churn.pipeline \
           --role-arn $SAGEMAKER_PIPELINE_ROLE_ARN \
           --tags "[{\"Key\":\"sagemaker:project-name\", \"Value\":\"${SAGEMAKER_PROJECT_NAME}\"}, {\"Key\":\"sagemaker:project-id\", \"Value\":\"${SAGEMAKER_PROJECT_ID}\"}]" \
-          --kwargs "{\"region\":\"${AWS_REGION}\",\"role\":\"${SAGEMAKER_PIPELINE_ROLE_ARN}\",\"default_bucket\":\"${ARTIFACT_BUCKET}\",\"pipeline_name\":\"${SAGEMAKER_PROJECT_NAME_ID}\",\"model_package_group_name\":\"${SAGEMAKER_PROJECT_NAME_ID}\",\"base_job_prefix\":\"${SAGEMAKER_PROJECT_NAME_ID}\"}"
+          --kwargs "{\"region\":\"${AWS_REGION}\",\"role\":\"${SAGEMAKER_PIPELINE_ROLE_ARN}\",\"default_bucket\":\"${ARTIFACT_BUCKET}\",\"pipeline_name\":\"${SAGEMAKER_PROJECT_NAME_ID}\",\"model_package_group_name\":\"${SAGEMAKER_PROJECT_NAME_ID}\"}"
       - echo "Create/Update of the SageMaker Pipeline and execution completed."


### PR DESCRIPTION
*Issue #, if available:*
None. Here describes the issue:

As defined in `get_pipeline()` in [pipeline.py](https://github.com/aws-samples/amazon-sagemaker-immersion-day/blob/master/ML%20Pipelines%20scripts/pipeline.py), `get_pipeline` cannot receive argument `project_id`, but codebuild pass this argument based on this `codebuild-buildspec.yml`, which causes the following  error:
```
[Container] 2022/11/08 18:03:30 Running command run-pipeline --module-name pipelines.customer_churn.pipeline \
  --role-arn $SAGEMAKER_PIPELINE_ROLE_ARN \
  --tags "[{\"Key\":\"sagemaker:project-name\", \"Value\":\"${SAGEMAKER_PROJECT_NAME}\"}, {\"Key\":\"sagemaker:project-id\", \"Value\":\"${SAGEMAKER_PROJECT_ID}\"}]" \
  --kwargs "{\"region\":\"${AWS_REGION}\",\"role\":\"${SAGEMAKER_PIPELINE_ROLE_ARN}\",\"default_bucket\":\"${ARTIFACT_BUCKET}\",\"pipeline_name\":\"${SAGEMAKER_PROJECT_NAME_ID}\",\"model_package_group_name\":\"${SAGEMAKER_PROJECT_NAME_ID}\",\"base_job_prefix\":\"${SAGEMAKER_PROJECT_NAME_ID}\",\"project_id\":\"${SAGEMAKER_PROJECT_ID}\"}"

Exception: get_pipeline() got an unexpected keyword argument 'project_id' Traceback (most recent call last):
  File "/root/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pipelines/run_pipeline.py", line 77, in main
    pipeline = get_pipeline_driver(args.module_name, args.kwargs)
  File "/root/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pipelines/_utils.py", line 33, in get_pipeline_driver
    return _imports.get_pipeline(**kwargs)
TypeError: get_pipeline() got an unexpected keyword argument 'project_id'

```

*Description of changes:*
Just removing `project_id` from `codebuild-buildspec.yml`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
