### PR TITLE
fixing column drop in build train deploy processing lab

### DIFF
--- a/processing_xgboost.ipynb
+++ b/processing_xgboost.ipynb
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "isConfigCell": true
    },
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,17 +280,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2021-06-10 17:39:22    3545009 train.csv\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# cell 09\n",
     "!aws s3 ls $train_path/"
@@ -476,7 +468,7 @@
     "\n",
     "test_x = pd.read_csv('/tmp/test_x.csv', names=[f'{i}' for i in range(59)])\n",
     "test_y = pd.read_csv('/tmp/test_y.csv', names=['y'])\n",
-    "predictions = predict(test_x.drop(test_x.columns[0], axis=1).to_numpy(), xgb_predictor)"
+    "predictions = predict(test_x.to_numpy(), xgb_predictor)"
    ]
   },
   {
@@ -676,7 +668,7 @@
   "kernelspec": {
    "display_name": "Python 3 (Data Science)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:eu-west-1:470317259841:image/datascience-1.0"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/datascience-1.0"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Cell 16 inside of the the notebook for Lab 2 (`processing_xgboost.ipynb`) was dropping the first column of the `test_x` dataframe. However, the first column is a feature which the model is expecting, not the label which is in the `train` and `validation` dataframe. This change removes the column drop which was causing the model predictions be in inaccurate.

[@harryxpan](https://github.com/harryxpan) first reported this bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
