### PR TITLE
fix build error due to get_pipeline definition

### DIFF
--- a/ML Pipelines scripts/pipeline.py
+++ b/ML Pipelines scripts/pipeline.py
@@ -89,6 +89,7 @@ def get_pipeline(
     model_package_group_name="CustomerChurnPackageGroup",  # Choose any name
     pipeline_name="CustomerChurnDemo-p-ewf8t7lvhivm",  # You can find your pipeline name in the Studio UI (project -> Pipelines -> name)
     base_job_prefix="CustomerChurn",  # Choose any name
+    sagemaker_project_name=None
 ):
     """Gets a SageMaker ML Pipeline instance working with on CustomerChurn data.
     Args:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Change in function definition of get_pipeline() to address following error: 
TypeError: get_pipeline() got an unexpected keyword argument 'sagemaker_project_name'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
