### PR TITLE
[Lab3c. Bring your own container] fix pandas s3 download

### DIFF
--- a/bring-custom-container.ipynb
+++ b/bring-custom-container.ipynb
@@ -926,6 +926,7 @@
     "# Define IAM role\n",
     "import boto3\n",
     "import re\n",
+    "import io\n",
     "\n",
     "import os\n",
     "import numpy as np\n",
@@ -1185,8 +1186,9 @@
    ],
    "source": [
     "# cell 08\n",
-    "\n",
-    "shape=pd.read_csv(file_location, header=None)\n",
+    "s3 = boto3.client('s3')\n",
+    "obj = s3.get_object(Bucke=sess.default_bucket(), Key=S3_prefix+'/iris.csv')\n",
+    "shape = pd.read_csv(io.BytesIO(obj['Body'].read()), header=None)\n",
     "shape.sample(3)"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the step __[Preparing test data to run inferences](https://catalog.us-east-1.prod.workshops.aws/workshops/63069e26-921c-4ce1-9cc7-dd882ff62575/en-US/lab3/option2#preparing-test-data-to-run-inferences)__, pandas fails to get the object from s3 bucket due to dependency on boto3.  
This PR updates the section to explicitly get the object from s3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
