### PR TITLE
Scope IAM permissions to sagemaker and not just sagemaker-studio.  More convenient if running Immersion Day in vanilla Jupyter notebook outside SM Studio.

### DIFF
--- a/iam-policy-sm-cb.txt
+++ b/iam-policy-sm-cb.txt
@@ -9,12 +9,12 @@
                 "codebuild:BatchGetBuilds",
                 "codebuild:StartBuild"
             ],
-            "Resource": "arn:aws:codebuild:*:*:project/sagemaker-studio*"
+            "Resource": "arn:aws:codebuild:*:*:project/sagemaker*"
         },
         {
             "Effect": "Allow",
             "Action": "logs:CreateLogStream",
-            "Resource": "arn:aws:logs:*:*:log-group:/aws/codebuild/sagemaker-studio*"
+            "Resource": "arn:aws:logs:*:*:log-group:/aws/codebuild/sagemaker*"
         },
         {
             "Effect": "Allow",
@@ -22,7 +22,7 @@
                 "logs:GetLogEvents",
                 "logs:PutLogEvents"
             ],
-            "Resource": "arn:aws:logs:*:*:log-group:/aws/codebuild/sagemaker-studio*:log-stream:*"
+            "Resource": "arn:aws:logs:*:*:log-group:/aws/codebuild/sagemaker*:log-stream:*"
         },
         {
             "Effect": "Allow",
@@ -43,7 +43,7 @@
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:PutImage"
             ],
-            "Resource": "arn:aws:ecr:*:*:repository/sagemaker-studio*"
+            "Resource": "arn:aws:ecr:*:*:repository/sagemaker*"
         },
         {
             "Effect": "Allow",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Running the SageMaker Immersion Day can be convenient in a vanilla Jupyter notebook.  This change allows IAM permissions to apply sagemaker resources and not just those within sagemaker-studio.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
