### PR TITLE
Add sklearn-end2end to bring-your-own-model

### DIFF
--- a/bring-your-own-model/sklearn-end2end.ipynb
+++ b/bring-your-own-model/sklearn-end2end.ipynb
@@ -1,0 +1,779 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Targeting Direct Marketing with Amazon SageMaker and Scikit-Learn\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Background\n",
+    "Direct marketing, either through mail, email, phone, etc., is a common tactic to acquire customers.  Because resources and a customer's attention is limited, the goal is to only target the subset of prospects who are likely to engage with a specific offer.  Predicting those potential customers based on readily available information like demographics, past interactions, and environmental factors is a common machine learning problem.\n",
+    "\n",
+    "This notebook presents an example problem to predict if a customer will enroll for a term deposit at a bank, after one or more phone calls.  The steps include:\n",
+    "\n",
+    "* Preparing your Amazon SageMaker notebook\n",
+    "* Downloading data from the internet into Amazon SageMaker\n",
+    "* Investigating and transforming the data so that it can be fed to Amazon SageMaker algorithms\n",
+    "* Estimating a model using the Gradient Boosting algorithm\n",
+    "* Evaluating the effectiveness of the model\n",
+    "* Setting the model up to make on-going predictions\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Preparation\n",
+    "\n",
+    "_This notebook was created and tested on an ml.m4.xlarge notebook instance._\n",
+    "\n",
+    "Let's start by specifying:\n",
+    "\n",
+    "- The S3 bucket and prefix that you want to use for training and model data.  This should be within the same region as the Notebook Instance, training, and hosting.\n",
+    "- The IAM role arn used to give training and hosting access to your data. See the documentation for how to create these.  Note, if more than one role is required for notebook instances, training, and/or hosting, please replace the boto regexp with a the appropriate full IAM role arn string(s)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "isConfigCell": true
+   },
+   "outputs": [],
+   "source": [
+    "# cell 01\n",
+    "import sagemaker\n",
+    "bucket=sagemaker.Session().default_bucket()\n",
+    "prefix = 'sagemaker/sklearn-end-2end-immday'\n",
+    " \n",
+    "# Define IAM role\n",
+    "import boto3\n",
+    "import re\n",
+    "from sagemaker import get_execution_role\n",
+    "\n",
+    "role = get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's bring in the Python libraries that we'll use throughout the analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 02\n",
+    "import numpy as np                                # For matrix operations and numerical processing\n",
+    "import pandas as pd                               # For munging tabular data\n",
+    "import matplotlib.pyplot as plt                   # For charts and visualizations\n",
+    "from IPython.display import Image                 # For displaying images in the notebook\n",
+    "from IPython.display import display               # For displaying outputs in the notebook\n",
+    "from time import gmtime, strftime                 # For labeling SageMaker models, endpoints, etc.\n",
+    "import sys                                        # For writing outputs to notebook\n",
+    "import math                                       # For ceiling function\n",
+    "import json                                       # For parsing hosting outputs\n",
+    "import os                                         # For manipulating filepath names\n",
+    "import sagemaker \n",
+    "import zipfile     # Amazon SageMaker's Python SDK provides many helper functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 03\n",
+    "pd.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make sure pandas version is set to 1.2.4 or later. If it is not the case, restart the kernel before going further"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Data\n",
+    "Let's start by downloading the [direct marketing dataset](https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip) from the sample data s3 bucket. \n",
+    "\n",
+    "\\[Moro et al., 2014\\] S. Moro, P. Cortez and P. Rita. A Data-Driven Approach to Predict the Success of Bank Telemarketing. Decision Support Systems, Elsevier, 62:22-31, June 2014\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 04\n",
+    "!wget https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip\n",
+    "\n",
+    "with zipfile.ZipFile('bank-additional.zip', 'r') as zip_ref:\n",
+    "    zip_ref.extractall('.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now lets read this into a Pandas data frame and take a look."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 05\n",
+    "data = pd.read_csv('./bank-additional/bank-additional-full.csv')\n",
+    "pd.set_option('display.max_columns', 500)     # Make sure we can see all of the columns\n",
+    "pd.set_option('display.max_rows', 20)         # Keep the output on one page\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will store this natively in S3 to then process it with SageMaker Processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 06\n",
+    "from sagemaker import Session\n",
+    "\n",
+    "sess = Session()\n",
+    "input_source = sess.upload_data('./bank-additional/bank-additional-full.csv', bucket=bucket, key_prefix=f'{prefix}/input_data')\n",
+    "input_source"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Feature Engineering with Amazon SageMaker Processing\n",
+    "\n",
+    "Amazon SageMaker Processing allows you to run steps for data pre- or post-processing, feature engineering, data validation, or model evaluation workloads on Amazon SageMaker. Processing jobs accept data from Amazon S3 as input and store data into Amazon S3 as output.\n",
+    "\n",
+    "![processing](https://sagemaker.readthedocs.io/en/stable/_images/amazon_sagemaker_processing_image1.png)\n",
+    "\n",
+    "Here, we'll import the dataset and transform it with SageMaker Processing, which can be used to process terabytes of data in a SageMaker-managed cluster separate from the instance running your notebook server. In a typical SageMaker workflow, notebooks are only used for prototyping and can be run on relatively inexpensive and less powerful instances, while processing, training and model hosting tasks are run on separate, more powerful SageMaker-managed instances.  SageMaker Processing includes off-the-shelf support for Scikit-learn, as well as a Bring Your Own Container option, so it can be used with many different data transformation technologies and tasks.    \n",
+    "\n",
+    "To use SageMaker Processing, simply supply a Python data preprocessing script as shown below.  For this example, we're using a SageMaker prebuilt Scikit-learn container, which includes many common functions for processing data.  There are few limitations on what kinds of code and operations you can run, and only a minimal contract:  input and output data must be placed in specified directories.  If this is done, SageMaker Processing automatically loads the input data from S3 and uploads transformed data back to S3 when the job is complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 07\n",
+    "%%writefile preprocessing.py\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import argparse\n",
+    "import os\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
+    "\n",
+    "def _parse_args():\n",
+    "\n",
+    "    parser = argparse.ArgumentParser()\n",
+    "\n",
+    "    # Data, model, and output directories\n",
+    "    # model_dir is always passed in from SageMaker. By default this is a S3 path under the default bucket.\n",
+    "    parser.add_argument('--filepath', type=str, default='/opt/ml/processing/input/')\n",
+    "    parser.add_argument('--filename', type=str, default='bank-additional-full.csv')\n",
+    "    parser.add_argument('--outputpath', type=str, default='/opt/ml/processing/output/')\n",
+    "    parser.add_argument('--categorical_features', type=str, default='y, job, marital, education, default, housing, loan, contact, month, day_of_week, poutcome')\n",
+    "\n",
+    "    return parser.parse_known_args()\n",
+    "\n",
+    "if __name__==\"__main__\":\n",
+    "    # Process arguments\n",
+    "    args, _ = _parse_args()\n",
+    "    # Load data\n",
+    "    df = pd.read_csv(os.path.join(args.filepath, args.filename))\n",
+    "    # Change the value . into _\n",
+    "    df = df.replace(regex=r'\\.', value='_')\n",
+    "    df = df.replace(regex=r'\\_$', value='')\n",
+    "    # Add two new indicators\n",
+    "    df[\"no_previous_contact\"] = (df[\"pdays\"] == 999).astype(int)\n",
+    "    df[\"not_working\"] = df[\"job\"].isin([\"student\", \"retired\", \"unemployed\"]).astype(int)\n",
+    "    df = df.drop(['duration', 'emp.var.rate', 'cons.price.idx', 'cons.conf.idx', 'euribor3m', 'nr.employed'], axis=1)\n",
+    "    # Encode the categorical features\n",
+    "    df = pd.get_dummies(df)\n",
+    "    # Train, test, validation split\n",
+    "    train_data, validation_data, test_data = np.split(df.sample(frac=1, random_state=42), [int(0.7 * len(df)), int(0.9 * len(df))])   # Randomly sort the data then split out first 70%, second 20%, and last 10%\n",
+    "    # Local store\n",
+    "    pd.concat([train_data['y_yes'], train_data.drop(['y_yes','y_no'], axis=1)], axis=1).to_csv(os.path.join(args.outputpath, 'train/train.csv'), index=False, header=False)\n",
+    "    pd.concat([validation_data['y_yes'], validation_data.drop(['y_yes','y_no'], axis=1)], axis=1).to_csv(os.path.join(args.outputpath, 'validation/validation.csv'), index=False, header=False)\n",
+    "    test_data['y_yes'].to_csv(os.path.join(args.outputpath, 'test/test_y.csv'), index=False, header=False)\n",
+    "    test_data.drop(['y_yes','y_no'], axis=1).to_csv(os.path.join(args.outputpath, 'test/test_x.csv'), index=False, header=False)\n",
+    "    print(\"## Processing complete. Exiting.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before starting the SageMaker Processing job, we instantiate a `SKLearnProcessor` object.  This object allows you to specify the instance type to use in the job, as well as how many instances.  Although the Boston Housing dataset is quite small, we'll use two instances to showcase how easy it is to spin up a cluster for SageMaker Processing.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 08\n",
+    "train_path = f\"s3://{bucket}/{prefix}/train\"\n",
+    "validation_path = f\"s3://{bucket}/{prefix}/validation\"\n",
+    "test_path = f\"s3://{bucket}/{prefix}/test\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 09\n",
+    "from sagemaker.sklearn.processing import SKLearnProcessor\n",
+    "from sagemaker.processing import ProcessingInput, ProcessingOutput\n",
+    "from sagemaker import get_execution_role\n",
+    "\n",
+    "\n",
+    "sklearn_processor = SKLearnProcessor(\n",
+    "    framework_version=\"0.23-1\",\n",
+    "    role=get_execution_role(),\n",
+    "    instance_type=\"ml.m5.large\",\n",
+    "    instance_count=1, \n",
+    "    base_job_name='sm-immday-skprocessing'\n",
+    ")\n",
+    "\n",
+    "sklearn_processor.run(\n",
+    "    code='preprocessing.py',\n",
+    "    inputs=[\n",
+    "        ProcessingInput(\n",
+    "            source=input_source, \n",
+    "            destination=\"/opt/ml/processing/input\",\n",
+    "            s3_input_mode=\"File\",\n",
+    "            s3_data_distribution_type=\"ShardedByS3Key\"\n",
+    "        )\n",
+    "    ],\n",
+    "    outputs=[\n",
+    "        ProcessingOutput(\n",
+    "            output_name=\"train_data\", \n",
+    "            source=\"/opt/ml/processing/output/train\",\n",
+    "            destination=train_path,\n",
+    "        ),\n",
+    "        ProcessingOutput(output_name=\"validation_data\", source=\"/opt/ml/processing/output/validation\", destination=validation_path),\n",
+    "        ProcessingOutput(output_name=\"test_data\", source=\"/opt/ml/processing/output/test\", destination=test_path),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## End of Lab 1\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Training\n",
+    "Now we know that most of our features have skewed distributions, some are highly correlated with one another, and some appear to have non-linear relationships with our target variable.  Also, for targeting future prospects, good predictive accuracy is preferred to being able to explain why that prospect was targeted.  Taken together, these aspects make gradient boosted trees a good candidate algorithm.\n",
+    "\n",
+    "There are several intricacies to understanding the algorithm, but at a high level, gradient boosted trees works by combining predictions from many simple models, each of which tries to address the weaknesses of the previous models.  By doing this the collection of simple models can actually outperform large, complex models.  Other Amazon SageMaker notebooks elaborate on gradient boosting trees further and how they differ from similar algorithms.\n",
+    "\n",
+    "In this notebook we show how to use Amazon SageMaker to develop, train, tune and deploy a Scikit-Learn based ML model (Random Forest). More info on Scikit-Learn can be found [here](https://scikit-learn.org/stable/index.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 10\n",
+    "s3_input_train = sagemaker.inputs.TrainingInput(s3_data=train_path.format(bucket, prefix), content_type='csv')\n",
+    "s3_input_validation = sagemaker.inputs.TrainingInput(s3_data=validation_path.format(bucket, prefix), content_type='csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The below script contains both training and inference functionality and can run both in SageMaker Training hardware or locally (desktop, SageMaker notebook, on prem, etc). Detailed guidance here https://sagemaker.readthedocs.io/en/stable/using_sklearn.html#preparing-the-scikit-learn-training-script"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 11\n",
+    "%%writefile sklearn-train.py\n",
+    "\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "from joblib import dump, load\n",
+    "import pandas as pd, numpy as np, os, argparse\n",
+    "\n",
+    "# inference function - tells SageMaker how to load the model\n",
+    "def model_fn(model_dir):\n",
+    "    clf = load(os.path.join(model_dir, \"model.joblib\"))\n",
+    "    return clf\n",
+    "\n",
+    "# Argument parser\n",
+    "def _parse_args():\n",
+    "    parser = argparse.ArgumentParser()\n",
+    "    # Hyperparameters\n",
+    "    parser.add_argument(\"--n-estimators\", type=int, default=10)\n",
+    "    parser.add_argument(\"--min-samples-leaf\", type=int, default=3)\n",
+    "    # Data, model, and output directories\n",
+    "    parser.add_argument(\"--model-dir\", type=str, default=os.environ.get(\"SM_MODEL_DIR\"))\n",
+    "    parser.add_argument(\"--train\", type=str, default=os.environ.get(\"SM_CHANNEL_TRAIN\"))\n",
+    "    parser.add_argument(\"--test\", type=str, default=os.environ.get(\"SM_CHANNEL_TEST\"))\n",
+    "    parser.add_argument(\"--train-file\", type=str, default=\"train.csv\")\n",
+    "    parser.add_argument(\"--test-file\", type=str, default=\"test.csv\")\n",
+    "    # Parse the arguments\n",
+    "    return parser.parse_known_args()\n",
+    "\n",
+    "# Main Training Loop\n",
+    "if __name__==\"__main__\":\n",
+    "    # Process arguments\n",
+    "    args, _ = _parse_args()\n",
+    "    # Load the dataset\n",
+    "    train_df = pd.read_csv(os.path.join(args.train, args.train_file))\n",
+    "    test_df = pd.read_csv(os.path.join(args.test, args.test_file))\n",
+    "    # Separate X and y\n",
+    "    X_train, y_train = train_df.drop(train_df.columns[0], axis=1), train_df[train_df.columns[0]]\n",
+    "    X_test, y_test = test_df.drop(test_df.columns[0], axis=1), test_df[test_df.columns[0]]\n",
+    "    # Define the model and train it\n",
+    "    model = RandomForestClassifier(\n",
+    "        n_estimators=args.n_estimators, min_samples_leaf=args.min_samples_leaf, n_jobs=-1\n",
+    "    )\n",
+    "    model.fit(X_train, y_train)\n",
+    "    # Evaluate the model performances\n",
+    "    print(f'Model Accuracy: {accuracy_score(y_test, model.predict(X_test))}')\n",
+    "    dump(model, os.path.join(args.model_dir, 'model.joblib'))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 12\n",
+    "# We use the Estimator from the SageMaker Python SDK\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.sklearn.estimator import SKLearn\n",
+    "\n",
+    "FRAMEWORK_VERSION = \"0.23-1\"\n",
+    "\n",
+    "# Define the Estimator from SageMaker (Script Mode)\n",
+    "sklearn_estimator = SKLearn(\n",
+    "    entry_point=\"sklearn-train.py\",\n",
+    "    role=get_execution_role(),\n",
+    "    instance_count=1,\n",
+    "    instance_type=\"ml.c5.xlarge\",\n",
+    "    framework_version=FRAMEWORK_VERSION,\n",
+    "    base_job_name=\"rf-scikit\",\n",
+    "    metric_definitions=[{\"Name\": \"model_accuracy\", \"Regex\": \"Model Accuracy: ([0-9.]+).*$\"}],\n",
+    "    hyperparameters={\n",
+    "        \"n-estimators\": 100,\n",
+    "        \"min-samples-leaf\": 3,\n",
+    "        \"test-file\": \"validation.csv\"\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "# Train the model (~5 minutes)\n",
+    "sklearn_estimator.fit({\"train\": s3_input_train, \"test\": s3_input_validation})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Hosting\n",
+    "Now that we've trained the algorithm on our data, let's deploy a model that's hosted behind a real-time endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 13\n",
+    "sklearn_predictor = sklearn_estimator.deploy(initial_instance_count=1,\n",
+    "                           instance_type='ml.m4.xlarge')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Evaluation\n",
+    "There are many ways to compare the performance of a machine learning model, but let's start by simply comparing actual to predicted values.  In this case, we're simply predicting whether the customer subscribed to a term deposit (`1`) or not (`0`), which produces a simple confusion matrix.\n",
+    "\n",
+    "First we'll need to determine how we pass data into and receive data from our endpoint.  Our data is currently stored as NumPy arrays in memory of our notebook instance.  To send it in an HTTP POST request, we'll serialize it as a CSV string and then decode the resulting CSV.\n",
+    "\n",
+    "*Note: For inference with CSV format, SageMaker XGBoost requires that the data does NOT include the target variable.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 14\n",
+    "sklearn_predictor.serializer = sagemaker.serializers.CSVSerializer()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we'll use a simple function to:\n",
+    "1. Loop over our test dataset\n",
+    "1. Split it into mini-batches of rows \n",
+    "1. Convert those mini-batches to CSV string payloads (notice, we drop the target variable from our dataset first)\n",
+    "1. Retrieve mini-batch predictions by invoking the XGBoost endpoint\n",
+    "1. Collect predictions and convert from the CSV output our model provides into a NumPy array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 15\n",
+    "!aws s3 cp $test_path/test_x.csv /tmp/test_x.csv\n",
+    "!aws s3 cp $test_path/test_y.csv /tmp/test_y.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 16\n",
+    "test_x = pd.read_csv('/tmp/test_x.csv', names=[f'{i}' for i in range(59)])\n",
+    "test_y = pd.read_csv('/tmp/test_y.csv', names=['y'])\n",
+    "predictions = sklearn_predictor.predict(test_x.values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll check our confusion matrix to see how well we predicted versus actuals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 17\n",
+    "pd.crosstab(index=test_y['y'].values, columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, of the ~4000 potential customers, we predicted 136 would subscribe and 94 of them actually did.  We also had 389 subscribers who subscribed that we did not predict would.  This is less than desirable, but the model can (and should) be tuned to improve this.  Most importantly, note that with minimal effort, our model produced accuracies similar to those published [here](http://media.salford-systems.com/video/tutorial/2015/targeted_marketing.pdf).\n",
+    "\n",
+    "_Note that because there is some element of randomness in the algorithm's subsample, your results may differ slightly from the text written above._"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Inferences for an Entire Dataset with Batch Transform\n",
+    "\n",
+    "To get inferences for an entire dataset, use batch transform. With batch transform, you create a batch transform job using a trained model and the dataset, which must be stored in Amazon S3. Amazon SageMaker saves the inferences in an S3 bucket that you specify when you create the batch transform job. Batch transform manages all of the compute resources required to get inferences. This includes launching instances and deleting them after the batch transform job has completed. Batch transform manages interactions between the data and the model with an object within the instance node called an agent.\n",
+    "\n",
+    "Use batch transform when you:\n",
+    "\n",
+    "- Want to get inferences for an entire dataset and index them to serve inferences in real time\n",
+    "- Don't need a persistent endpoint that applications (for example, web or mobile apps) can call to get inferences\n",
+    "- Don't need the subsecond latency that SageMaker hosted endpoints provide\n",
+    "- You can also use batch transform to preprocess your data before using it to train a new model or generate inferences.\n",
+    "\n",
+    "The following diagram shows the workflow of a batch transform job:\n",
+    "\n",
+    "![batch_transform](https://docs.aws.amazon.com/sagemaker/latest/dg/images/batch-transform-v2.png)\n",
+    "\n",
+    "To perform a batch transform, create a batch transform job using either the SageMaker console or the API. Provide the following:\n",
+    "\n",
+    "- The path to the S3 bucket where you've stored the data that you want to transform.\n",
+    "- The compute resources that you want SageMaker to use for the transform job. Compute resources are machine learning (ML) compute instances that are managed by SageMaker.\n",
+    "- The path to the S3 bucket where you want to store the output of the job.\n",
+    "- The name of the SageMaker model that you want to use to create inferences. You must use a model that you have already created either with the [CreateModel](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateModel.html) operation or the console.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 18\n",
+    "transformer_output_path = f\"s3://{bucket}/{prefix}/transformer-output\"\n",
+    "\n",
+    "sklearn_transformer = sklearn_estimator.transformer(\n",
+    "    instance_count=1,\n",
+    "    instance_type='ml.m5.large',\n",
+    "    output_path=transformer_output_path\n",
+    ")\n",
+    "\n",
+    "sklearn_transformer.transform(\n",
+    "    data=f'{test_path}/test_x.csv',\n",
+    "    data_type='S3Prefix',\n",
+    "    content_type='text/csv'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 19\n",
+    "!aws s3 cp $transformer_output_path/test_x.csv.out /tmp/predictions.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 20\n",
+    "import json\n",
+    "\n",
+    "with open('/tmp/predictions.txt', 'r') as r:\n",
+    "    a = r.read()[1:-1].split(', ')\n",
+    "    predictions = np.asarray(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 21\n",
+    "pd.crosstab(index=test_y['y'].values, columns=predictions, rownames=['actuals'], colnames=['predictions'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Automatic model Tuning (optional)\n",
+    "Amazon SageMaker automatic model tuning, also known as hyperparameter tuning, finds the best version of a model by running many training jobs on your dataset using the algorithm and ranges of hyperparameters that you specify. It then chooses the hyperparameter values that result in a model that performs the best, as measured by a metric that you choose.\n",
+    "For example, suppose that you want to solve a binary classification problem on this marketing dataset. Your goal is to maximize the area under the curve (auc) metric of the algorithm by training an XGBoost Algorithm model. You don't know which values of the eta, alpha, min_child_weight, and max_depth hyperparameters to use to train the best model. To find the best values for these hyperparameters, you can specify ranges of values that Amazon SageMaker hyperparameter tuning searches to find the combination of values that results in the training job that performs the best as measured by the objective metric that you chose. Hyperparameter tuning launches training jobs that use hyperparameter values in the ranges that you specified, and returns the training job with highest auc.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 22\n",
+    "from sagemaker.tuner import IntegerParameter, CategoricalParameter, ContinuousParameter, HyperparameterTuner\n",
+    "hyperparameter_ranges = {\"n-estimators\": IntegerParameter(50, 250), \"min-samples-leaf\": IntegerParameter(1, 10)}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 23\n",
+    "objective_metric_name = 'model_accuracy'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 24\n",
+    "tuner = HyperparameterTuner(sklearn_estimator,\n",
+    "                            objective_metric_name,\n",
+    "                            hyperparameter_ranges,\n",
+    "                            metric_definitions=[{\"Name\": \"model_accuracy\", \"Regex\": \"Model Accuracy: ([0-9.]+).*$\"}],\n",
+    "                            objective_type='Maximize',\n",
+    "                            max_jobs=9,\n",
+    "                            max_parallel_jobs=3)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 25\n",
+    "tuner.fit({'train': s3_input_train, 'test': s3_input_validation})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 26\n",
+    "boto3.client('sagemaker').describe_hyper_parameter_tuning_job(\n",
+    "HyperParameterTuningJobName=tuner.latest_tuning_job.job_name)['HyperParameterTuningJobStatus']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 27\n",
+    "# return the best training job name\n",
+    "tuner.best_training_job()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 28\n",
+    "#  Deploy the best trained or user specified model to an Amazon SageMaker endpoint\n",
+    "tuner_predictor = tuner.deploy(initial_instance_count=1, instance_type='ml.m4.xlarge')\n",
+    "tuner_predictor.serializer = sagemaker.serializers.CSVSerializer()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 29\n",
+    "# Deploy the best one and predict\n",
+    "predictions = tuner_predictor.predict(test_x.values)\n",
+    "pd.crosstab(index=test_y['y'].values, columns=np.round(predictions), rownames=['actuals'], colnames=['predictions'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Extensions\n",
+    "\n",
+    "This example analyzed a relatively small dataset, but utilized Amazon SageMaker features such as distributed, managed training and real-time model hosting, which could easily be applied to much larger problems.  In order to improve predictive accuracy further, we could tweak value we threshold our predictions at to alter the mix of false-positives and false-negatives, or we could explore techniques like hyperparameter tuning.  In a real-world scenario, we would also spend more time engineering features by hand and would likely look for additional datasets to include which contain customer information not available in our initial dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (Optional) Clean-up\n",
+    "\n",
+    "If you are done with this notebook, please run the cell below.  This will remove the hosted endpoint you created and avoid any charges from a stray instance being left on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 30\n",
+    "sklearn_predictor.delete_endpoint(delete_endpoint_config=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cell 31\n",
+    "tuner_predictor.delete_endpoint(delete_endpoint_config=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3 (Data Science)",
+   "language": "python",
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:eu-west-1:470317259841:image/datascience-1.0"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  },
+  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
sklearn-end2end was one good example of bring-your-own-model in sagemaker immersion day repo, including bring-your-own-script for processing and training, along with both endpoint deployment and batch inference.
Ref: https://github.com/aws-samples/amazon-sagemaker-immersion-day/blob/dependabot/pip/sagemaker-clarify/computer_vision/mxnet-1.9.1/sklearn-end2end.ipynb

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
